### PR TITLE
Proversity/staging hidden discussion

### DIFF
--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -59,7 +59,7 @@ def _get_course(course_key, user):
         course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)
     except Http404:
         raise CourseNotFoundError("Course not found.")
-    if not any([tab.type == 'discussion' and tab.is_enabled(course, user) for tab in course.tabs]):
+    if not any([tab.type == 'discussion' and tab.is_enabled(course, user) and not tab.is_hidden for tab in course.tabs]):
         raise DiscussionDisabledError("Discussion is disabled for the course.")
     return course
 

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -62,9 +62,6 @@ class DiscussionTab(EnrolledTab):
 
     @classmethod
     def is_enabled(cls, course, user=None):
-        for tab in course.tabs:
-            if tab.type == "discussion" and tab.is_hidden:
-                 return False
         if not super(DiscussionTab, cls).is_enabled(course, user):
             return False
         return utils.is_discussion_enabled(course.id)

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -62,6 +62,9 @@ class DiscussionTab(EnrolledTab):
 
     @classmethod
     def is_enabled(cls, course, user=None):
+        for tab in course.tabs:
+            if tab.type == "discussion" and tab.is_hidden:
+                 return False
         if not super(DiscussionTab, cls).is_enabled(course, user):
             return False
         return utils.is_discussion_enabled(course.id)


### PR DESCRIPTION
@jagonzalr @renevatium Herewith Changes to provide a 404 on api call to 

`GET /api/discussion/v1/courses/course-v1...` 

if the Discussion Tab is hidden.
