### PR TITLE
Make sure infoSidebarName is always set regardless of enabled boolean…

### DIFF
--- a/cms/templates/course_info.html
+++ b/cms/templates/course_info.html
@@ -58,9 +58,15 @@ from openedx.core.djangolib.js_utils import (
       </div>
     </section>
     % if not context_course.course_home_sidebar_enabled:
-      <section class="content">
-        <a href="/settings/advanced/${course_locator}" class=" button new-button" style="float: right;">${_(context_course.info_sidebar_name)} <i class="icon fa fa-question" style="padding-bottom: 3%;"></i></a>
-    </section>
+      % if len(context_course.info_sidebar_name) == 0:
+        <section class="content">
+          <a href="/settings/advanced/${course_locator}" class=" button new-button" style="float: right;">Course Home Sidebar <i class="icon fa fa-question" style="padding-bottom: 3%;"></i></a>
+        </section>
+      % else:
+        <section class="content">
+          <a href="/settings/advanced/${course_locator}" class=" button new-button" style="float: right;">${_(context_course.info_sidebar_name)} <i class="icon fa fa-question" style="padding-bottom: 3%;"></i></a>
+        </section>
+      % endif
     % endif
   </div>
 
@@ -72,11 +78,11 @@ from openedx.core.djangolib.js_utils import (
             <ol class="update-list" id="course-update-list"></ol>
           </article>
         </div>
-        % if context_course.course_home_sidebar_enabled:
           <script>
             var infoSidebarName = "${_(context_course.info_sidebar_name)}";
           </script>
-        <div class="sidebar course-handouts" id="course-handouts-view"></div>
+        % if context_course.course_home_sidebar_enabled:
+          <div class="sidebar course-handouts" id="course-handouts-view"></div>
         % endif
       </div>
     </div>

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -437,7 +437,7 @@ class CourseFields(object):
             "Enter the heading that you want students to see above your course handouts on the Course Home page. "
             "Your course handouts appear in the right panel of the page."
         ),
-        scope=Scope.settings, default=_('Course Handouts'))
+        scope=Scope.settings, default=_('Course Home Sidebar'))
     course_home_sidebar_enabled = Boolean(
         display_name=_("Enable the Course Home Sidebar"),
         help=_(


### PR DESCRIPTION
Fixed … (logic error here). Make sure Heading in studio also catches the empty string condition. A more elegant solution is to provide empty string validation on the setting itself.
