### PR TITLE
Proversity/filter staff from reports

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1881,6 +1881,7 @@ def get_anon_ids(request, course_id):  # pylint: disable=unused-argument
 
     students = User.objects.filter(
         courseenrollment__course_id=course_id,
+        is_staff=0,
     ).order_by('id')
     header = ['User ID', 'Anonymized User ID', 'Course Specific Anonymized User ID']
     rows = [[s.id, unique_id_for_user(s, save=False), anonymous_id_for_user(s, course_id, save=False)] for s in students]

--- a/lms/djangoapps/instructor/views/gradebook_api.py
+++ b/lms/djangoapps/instructor/views/gradebook_api.py
@@ -72,7 +72,8 @@ def get_grade_book_page(request, course, course_key):
     current_offset = request.GET.get('offset', 0)
     enrolled_students = User.objects.filter(
         courseenrollment__course_id=course_key,
-        courseenrollment__is_active=1
+        courseenrollment__is_active=1,
+        is_staff=0,
     ).order_by('username').select_related("profile")
 
     total_students = enrolled_students.count()

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -392,7 +392,8 @@ def list_problem_responses(course_key, problem_location):
 
     smdat = StudentModule.objects.filter(
         course_id=course_key,
-        module_state_key=problem_key
+        module_state_key=problem_key,
+        student__is_staff=0,
     )
     smdat = smdat.order_by('student')
 

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -285,18 +285,13 @@ def list_may_enroll(course_key, features):
     """
     may_enroll_and_unenrolled = CourseEnrollmentAllowed.may_enroll_and_unenrolled(course_key)
 
-    non_staff_pool = User.objects.filter(
-        is_staff=0,
-    )
-
     def extract_student(student, features):
         """
         Build dict containing information about a single student.
         """
         return dict((feature, getattr(student, feature)) for feature in features)
 
-    non_staff_mask = [extract_student(student, features) for student in non_staff_pool]
-    return [extract_student(student, features) for student in may_enroll_and_unenrolled if student in non_staff_mask]
+    return [extract_student(student, features) for student in may_enroll_and_unenrolled]
 
 
 def get_proctored_exam_results(course_key, features):

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -214,6 +214,7 @@ def enrolled_students_features(course_key, features):
     students = User.objects.filter(
         courseenrollment__course_id=course_key,
         courseenrollment__is_active=1,
+        is_staff=0,
     ).order_by('username').select_related('profile')
 
     if include_cohort_column:

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -285,13 +285,18 @@ def list_may_enroll(course_key, features):
     """
     may_enroll_and_unenrolled = CourseEnrollmentAllowed.may_enroll_and_unenrolled(course_key)
 
+    non_staff_pool = User.objects.filter(
+        is_staff=0,
+    )
+
     def extract_student(student, features):
         """
         Build dict containing information about a single student.
         """
         return dict((feature, getattr(student, feature)) for feature in features)
 
-    return [extract_student(student, features) for student in may_enroll_and_unenrolled]
+    non_staff_mask = [extract_student(student, features) for student in non_staff_pool]
+    return [extract_student(student, features) for student in may_enroll_and_unenrolled if student in non_staff_mask]
 
 
 def get_proctored_exam_results(course_key, features):

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -672,7 +672,9 @@ def upload_grades_csv(_xmodule_instance_args, _entry_id, course_id, _task_input,
     start_time = time()
     start_date = datetime.now(UTC)
     status_interval = 100
-    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id)
+    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id).filter(
+        is_staff=0,
+    )
     task_progress = TaskProgress(action_name, enrolled_students.count(), start_time)
 
     fmt = u'Task: {task_id}, InstructorTask ID: {entry_id}, Course: {course_id}, Input: {task_input}'

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -916,7 +916,9 @@ def upload_problem_grade_report(_xmodule_instance_args, _entry_id, course_id, _t
     start_time = time()
     start_date = datetime.now(UTC)
     status_interval = 100
-    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id)
+    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id).filter(
+         is_staff=0,
+    )
     task_progress = TaskProgress(action_name, enrolled_students.count(), start_time)
 
     # This struct encapsulates both the display names of each static item in the


### PR DESCRIPTION
I have run test using:

`python ./manage.py lms test --verbosity=1 lms/djangoapps/instructor_analytics/tests/ --settings=test`

as a simple sanity check. They are passing which is nice, but I'm not sure how the filtering will affect the full lms suite - maybe something I can run overnight.

As per the waffle:

Leaving out:
1. Download a CSV of learners who can enroll. This option only finds learners who have been invited via email only, and may include staff members which is useful information.
2. View certificates issues (& its related download csv option). It contains no user information.
