### PR TITLE
Forgot password check email show error

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -216,6 +216,12 @@ def password_change_request_handler(request):
     email = user.email if user.is_authenticated() else request.POST.get('email')
 
     if email:
+        invalid_email = False
+        show_forgot_password_email_error = configuration_helpers.get_value(
+            'SHOW_FORGOT_PASSWORD_EMAIL_ERROR',
+            settings.FEATURES['SHOW_FORGOT_PASSWORD_EMAIL_ERROR']
+        )
+
         try:
             request_password_change(email, request.is_secure())
             user = user if user.is_authenticated() else User.objects.get(email=email)
@@ -224,10 +230,15 @@ def password_change_request_handler(request):
             AUDIT_LOG.info("Invalid password reset attempt")
             # Increment the rate limit counter
             limiter.tick_bad_request_counter(request)
+            invalid_email = True
 
-        return HttpResponse(status=200)
+        if not show_forgot_password_email_error or not invalid_email:
+            return HttpResponse(status=200)
+
+        return HttpResponseBadRequest(_("That e-mail address doesn't have an "
+            "associated user account. Are you sure you've registered?"))
     else:
-        return HttpResponseBadRequest(_("No email address provided."))
+        return HttpResponseBadRequest(_("No email address provided.")) 
 
 
 def update_context_for_enterprise(request, context):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -417,6 +417,9 @@ FEATURES = {
     # See https://cookieconsent.insites.com/ for more.
     'ENABLE_COOKIE_CONSENT': False,
 
+    # Show feedback when email does not exists when resetting password.
+    'SHOW_FORGOT_PASSWORD_EMAIL_ERROR': False,
+
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews


### PR DESCRIPTION
Setting the flag `SHOW_FORGOT_PASSWORD_EMAIL_ERROR=True` on `FEATURES` of `lms.env.json` will show an error when resetting the password in the forgot password view. The current behaviour is showing that everything went correct. Even though this is actually the correct way to do it because hackers we can activate this feature on the microsite level if any of the clients wants this.