### PR TITLE
CAM-5 Adding new SAML backend

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -5,6 +5,7 @@ import logging
 
 import requests
 from django.contrib.sites.models import Site
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from django.http import Http404
 from django.utils.functional import cached_property
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
@@ -120,13 +121,15 @@ class EdXSAMLIdentityProvider(SAMLIdentityProvider):
             for field in extra_field_definitions
         })
 
-        # TODO: ADD FEATURE FLAG
-        username_generator_settings = self.conf.get('USERNAME_GENERATOR', {})
+        if configuration_helpers.get_value(
+                'ENABLE_REGISTRATION_SUGGESTION_USERNAME',
+                settings.FEATURES.get('ENABLE_REGISTRATION_SUGGESTION_USERNAME', False)):
 
-        fullname = details['fullname']
-        username_generator = UsernameGenerator(username_generator_settings)
-        username = username_generator.hint_username(fullname)
-        details.update({'username': username})
+            username_generator_settings = self.conf.get('USERNAME_GENERATOR', {})
+            fullname = details['fullname']
+            username_generator = UsernameGenerator(username_generator_settings)
+            username = username_generator.hint_username(fullname)
+            details.update({'username': username})
 
         return details
 

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -5,6 +5,7 @@ import logging
 
 import requests
 from django.contrib.sites.models import Site
+from django.conf import settings
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from django.http import Http404
 from django.utils.functional import cached_property
@@ -122,13 +123,13 @@ class EdXSAMLIdentityProvider(SAMLIdentityProvider):
         })
 
         if configuration_helpers.get_value(
-                'ENABLE_REGISTRATION_SUGGESTION_USERNAME',
-                settings.FEATURES.get('ENABLE_REGISTRATION_SUGGESTION_USERNAME', False)):
+                'ENABLE_REGISTRATION_USERNAME_SUGGESTION',
+                settings.FEATURES.get('ENABLE_REGISTRATION_USERNAME_SUGGESTION', False)):
 
             username_generator_settings = self.conf.get('USERNAME_GENERATOR', {})
             fullname = details['fullname']
             username_generator = UsernameGenerator(username_generator_settings)
-            username = username_generator.hint_username(fullname)
+            username = username_generator.generate_username(fullname)
             details.update({'username': username})
 
         return details

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -5,6 +5,7 @@ import logging
 
 import requests
 from django.contrib.sites.models import Site
+from django.contrib.auth.models import User
 from django.http import Http404
 from django.utils.functional import cached_property
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
@@ -272,3 +273,21 @@ def get_saml_idp_class(idp_identifier_string):
             idp_identifier_string
         )
     return choices.get(idp_identifier_string, EdXSAMLIdentityProvider)
+
+
+class SAMLAuthBackendCampus(SAMLAuthBackend):
+
+    def get_user_details(self, response):
+        user_details = super(SAMLAuthBackendCampus, self).get_user_details(response)
+        fullname = user_details['fullname']
+        username = self.hint_username(fullname)
+        user_details.update({'username': username})
+        return user_details
+
+    def hint_username(self, fullname):
+        fullname = fullname.strip().lower()
+        validate_user = User.objects.filter(username=fullname)
+        if validate_user:
+            pass
+        else:
+            return fullname

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -276,7 +276,7 @@ def get_saml_idp_class(idp_identifier_string):
     return choices.get(idp_identifier_string, EdXSAMLIdentityProvider)
 
 
-class HintedUsernameSAMLAuthBackend(SAMLAuthBackend):
+class HintUsernameSAMLAuthBackend(SAMLAuthBackend):
     """Auth backend to hint a username"""
 
     def get_user_details(self, response):
@@ -284,7 +284,7 @@ class HintedUsernameSAMLAuthBackend(SAMLAuthBackend):
         Overrides get_user_details method of Python-SAML
         with the hinted username
         """
-        user_details = super(HintedUsernameSAMLAuthBackend, self).get_user_details(response)
+        user_details = super(HintUsernameSAMLAuthBackend, self).get_user_details(response)
         fullname = user_details['fullname']
         username = self.hint_username(fullname)
         user_details.update({'username': username})

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -10,7 +10,7 @@ from django.utils.functional import cached_property
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
 from social_core.exceptions import AuthForbidden
 
-from utils import UsernameGenerator, generate_username
+from utils import UsernameGenerator
 
 from openedx.core.djangoapps.theming.helpers import get_current_request
 
@@ -114,10 +114,20 @@ class EdXSAMLIdentityProvider(SAMLIdentityProvider):
         """
         details = super(EdXSAMLIdentityProvider, self).get_user_details(attributes)
         extra_field_definitions = self.conf.get('extra_field_definitions', [])
+
         details.update({
             field['name']: attributes[field['urn']][0] if field['urn'] in attributes else None
             for field in extra_field_definitions
         })
+
+        # TODO: ADD FEATURE FLAG
+        username_generator_settings = self.conf.get('USERNAME_GENERATOR', {})
+
+        fullname = details['fullname']
+        username_generator = UsernameGenerator(username_generator_settings)
+        username = username_generator.hint_username(fullname)
+        details.update({'username': username})
+
         return details
 
 
@@ -274,28 +284,3 @@ def get_saml_idp_class(idp_identifier_string):
             idp_identifier_string
         )
     return choices.get(idp_identifier_string, EdXSAMLIdentityProvider)
-
-
-class HintUsernameSAMLAuthBackend(SAMLAuthBackend):
-    """Auth backend to hint a username"""
-
-    def get_user_details(self, response):
-        """
-        Overrides get_user_details method of Python-SAML
-        with the hinted username
-        """
-        user_details = super(HintUsernameSAMLAuthBackend, self).get_user_details(response)
-        fullname = user_details['fullname']
-        username = self.hint_username(fullname)
-        user_details.update({'username': username})
-        return user_details
-
-    def hint_username(self, fullname):
-        """
-        First step to generates the username.
-        Returns the method that handles the job with the
-        hinted username.
-        """
-        generator = UsernameGenerator()
-        separator = generator.insert_separator(fullname)
-        return generate_username(separator)

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -10,7 +10,7 @@ from django.utils.functional import cached_property
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
 from social_core.exceptions import AuthForbidden
 
-from utils import generate_username
+from utils import GeneratorUsername, generate_username
 
 from openedx.core.djangoapps.theming.helpers import get_current_request
 
@@ -286,5 +286,6 @@ class HintedUsernameSAMLAuthBackend(SAMLAuthBackend):
         return user_details
 
     def hint_username(self, fullname):
-        username = fullname.replace(" ", "").lower()
-        return generate_username(username)
+        generator = GeneratorUsername()
+        separator = generator.separator(fullname)
+        return generate_username(separator)

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -10,7 +10,7 @@ from django.utils.functional import cached_property
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
 from social_core.exceptions import AuthForbidden
 
-from utils import GeneratorUsername, generate_username
+from utils import UsernameGenerator, generate_username
 
 from openedx.core.djangoapps.theming.helpers import get_current_request
 
@@ -277,8 +277,13 @@ def get_saml_idp_class(idp_identifier_string):
 
 
 class HintedUsernameSAMLAuthBackend(SAMLAuthBackend):
+    """Auth backend to hint a username"""
 
     def get_user_details(self, response):
+        """
+        Overrides get_user_details method of Python-SAML
+        with the hinted username
+        """
         user_details = super(HintedUsernameSAMLAuthBackend, self).get_user_details(response)
         fullname = user_details['fullname']
         username = self.hint_username(fullname)
@@ -286,6 +291,11 @@ class HintedUsernameSAMLAuthBackend(SAMLAuthBackend):
         return user_details
 
     def hint_username(self, fullname):
-        generator = GeneratorUsername()
-        separator = generator.separator(fullname)
+        """
+        First step to generates the username.
+        Returns the method that handles the job with the
+        hinted username.
+        """
+        generator = UsernameGenerator()
+        separator = generator.insert_separator(fullname)
         return generate_username(separator)

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -127,9 +127,9 @@ class EdXSAMLIdentityProvider(SAMLIdentityProvider):
                 settings.FEATURES.get('ENABLE_REGISTRATION_USERNAME_SUGGESTION', False)):
 
             username_generator_settings = self.conf.get('USERNAME_GENERATOR', {})
-            fullname = details['fullname']
+            username_base = details['username'] or details['fullname']
             username_generator = UsernameGenerator(username_generator_settings)
-            username = username_generator.generate_username(fullname)
+            username = username_generator.generate_username(username_base)
             details.update({'username': username})
 
         return details

--- a/common/djangoapps/third_party_auth/tests/test_utils.py
+++ b/common/djangoapps/third_party_auth/tests/test_utils.py
@@ -1,0 +1,138 @@
+import json
+
+import os.path
+from contextlib import contextmanager
+
+import django.test
+import mock
+from mock import MagicMock, patch
+from django.conf import settings
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from mako.template import Template
+from provider import constants
+from provider.oauth2.models import Client as OAuth2Client
+from storages.backends.overwrite import OverwriteStorage
+
+from third_party_auth.models import cache as config_cache
+from third_party_auth.models import (
+    LTIProviderConfig,
+    OAuth2ProviderConfig,
+    ProviderApiPermissions,
+    SAMLConfiguration,
+    SAMLProviderConfig
+)
+from third_party_auth.saml import EdXSAMLIdentityProvider, get_saml_idp_class
+from third_party_auth.utils import UsernameGenerator
+from third_party_auth.tests import testutil
+from third_party_auth.models import SAMLProviderConfig
+
+from third_party_auth.models import SAMLProviderConfig
+
+AUTH_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
+AUTH_FEATURE_ENABLED = AUTH_FEATURES_KEY in settings.FEATURES
+
+
+class GenerateUsernameTestCase(testutil.TestCase):
+
+    def setUp(self):
+        self.enable_saml()
+        self.user = User.objects.create(
+            username='my_self_user'
+        )
+        self.fullname = 'My Self User'
+
+    def test_separator(self):
+        """
+        The first step to generate a hinted username is the separator character of the
+        full name string. This test makes sure that we are generating a username replacing
+        all whitespaces by a character configured in settings or in site_configurations.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings= {'SEPARATOR': '.'}
+        )
+        generator = UsernameGenerator(saml.other_settings)
+        username = generator.replace_separator(self.fullname)
+        return self.assertEqual(username, "My.Self.User")
+
+    def test_generate_username_in_lowercase(self):
+        """
+        Test if the full name that comes from insert_separator method
+        it's converted in lowercase.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings= {'LOWER': True}
+        )
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.process_case('My_Self_User')
+        return self.assertEqual(new_username, 'my_self_user')
+
+    def test_generate_username_not_lowercase(self):
+        """
+        Test if the full name that comes from insert_separator method
+        is not converted in lowercase and preserves their original lowercases and
+        uppers cases.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings= {'LOWER': False}
+        )
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.process_case('My_Self_User')
+        return self.assertEqual(new_username, 'My_Self_User')
+
+    def test_generate_username_with_consecutive(self):
+        """
+        It should return a new user with a consecutive number.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings= {'RANDOM': False}
+        )
+
+        for i in range (1, 6):
+            User.objects.create(
+                username='my_self_user_{}'.format(i)
+            )
+        
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.generate_username(self.user.username)
+        # We have 6 users: Five created in the loop with a consecutive
+        # number and another one that comes from initial setUp,
+        # the first has not consecutive number due to is
+        # not neccesary append an differentiator. We expect a new user with
+        # the consecutive number 6.
+        return self.assertEqual(new_username, 'my_self_user_6')
+
+    @patch('third_party_auth.utils.UsernameGenerator.consecutive_or_random')
+    def test_generate_username_with_random(self, mock_random):
+        """
+        It should return a username with a random integer
+        at the end of the username generated.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings= {'RANDOM': True}
+        )
+        mock_random.return_value = 4589
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.generate_username(self.user.username)
+        return self.assertEqual(new_username, 'my_self_user_4589')

--- a/common/djangoapps/third_party_auth/tests/test_utils.py
+++ b/common/djangoapps/third_party_auth/tests/test_utils.py
@@ -111,7 +111,7 @@ class GenerateUsernameTestCase(testutil.TestCase):
             )
         
         generator = UsernameGenerator(saml.other_settings)
-        new_username = generator.generate_username(self.user.username)
+        new_username = generator.generate_username(self.fullname)
         # We have 6 users: Five created in the loop with a consecutive
         # number and another one that comes from initial setUp,
         # the first has not consecutive number due to is
@@ -134,7 +134,7 @@ class GenerateUsernameTestCase(testutil.TestCase):
         )
         mock_random.return_value = 4589
         generator = UsernameGenerator(saml.other_settings)
-        new_username = generator.generate_username(self.user.username)
+        new_username = generator.generate_username(self.fullname)
         return self.assertEqual(new_username, 'my_self_user_4589')
 
     def test_username_without_modifications(self):
@@ -143,6 +143,7 @@ class GenerateUsernameTestCase(testutil.TestCase):
         in database, should return the username without
         any modifications of suffix number.
         """
+    
         saml = self.configure_saml_provider(
             enabled=True,
             name="Saml Test",
@@ -151,8 +152,9 @@ class GenerateUsernameTestCase(testutil.TestCase):
             other_settings= {'RANDOM': True}
         )
 
-        not_existing_username = 'another_myself'
+        not_existing_user = 'Another Myself'
         generator = UsernameGenerator(saml.other_settings)
-        new_username = generator.generate_username(not_existing_username)
+        new_username = generator.generate_username(not_existing_user)
 
         return self.assertEqual(new_username, 'another_myself')
+

--- a/common/djangoapps/third_party_auth/tests/test_utils.py
+++ b/common/djangoapps/third_party_auth/tests/test_utils.py
@@ -119,7 +119,7 @@ class GenerateUsernameTestCase(testutil.TestCase):
         # the consecutive number 6.
         return self.assertEqual(new_username, 'my_self_user_6')
 
-    @patch('third_party_auth.utils.UsernameGenerator.consecutive_or_random')
+    @patch('third_party_auth.utils.UsernameGenerator.get_random')
     def test_generate_username_with_random(self, mock_random):
         """
         It should return a username with a random integer
@@ -136,3 +136,23 @@ class GenerateUsernameTestCase(testutil.TestCase):
         generator = UsernameGenerator(saml.other_settings)
         new_username = generator.generate_username(self.user.username)
         return self.assertEqual(new_username, 'my_self_user_4589')
+
+    def test_username_without_modifications(self):
+        """
+        If the provided username does not exists
+        in database, should return the username without
+        any modifications of suffix number.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings= {'RANDOM': True}
+        )
+
+        not_existing_username = 'another_myself'
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.generate_username(not_existing_username)
+
+        return self.assertEqual(new_username, 'another_myself')

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -318,7 +318,7 @@ class GenerateUsernameTestCase(TestCase):
         )
         self.fullname = 'My Self User'
 
-    @override_settings(FEATURES={'GENERATOR_USERNAME':{'SEPARATOR':'_', 'LOWER':True, 'RANDOM': False}})
+    @override_settings(FEATURES={'USERNAME_GENERATOR':{'SEPARATOR': '_', 'LOWER': True, 'RANDOM': False}})
     def test_separator(self):
         """
         The first step to generate a hinted username is the separator character of the
@@ -329,26 +329,26 @@ class GenerateUsernameTestCase(TestCase):
         username = generator.insert_separator(self.fullname)
         return self.assertEqual(username, "My_Self_User")
 
-    @override_settings(FEATURES={"GENERATOR_USERNAME":{'SEPARATOR':'_', 'LOWER':True, 'RANDOM': False}})
+    @override_settings(FEATURES={"USERNAME_GENERATOR":{'SEPARATOR': '_', 'LOWER':True, 'RANDOM': False}})
     def test_generate_username_in_lowercase(self):
         """
         Test if the full name that comes from insert_separator method
         it's converted in lowercase.
         """
-        new_username = generate_username('My_Self_Username')
-        return self.assertEqual('my_self_username', new_username)
+        new_username = generate_username('My_Self_User')
+        return self.assertEqual(new_username, 'my_self_user')
 
-    @override_settings(FEATURES={"GENERATOR_USERNAME":{'SEPARATOR':'_', 'LOWER':False, 'RANDOM': False}})
-    def test_generate_username_in_lowercase(self):
+    @override_settings(FEATURES={"USERNAME_GENERATOR":{'SEPARATOR': '_', 'LOWER': False, 'RANDOM': False}})
+    def test_generate_username_not_lowercase(self):
         """
         Test if the full name that comes from insert_separator method
         is not converted in lowercase and preserves their original lowercases and
         uppers cases.
         """
-        new_username = generate_username('My_Self_Username')
-        return self.assertEqual('My_Self_Username', new_username)
+        new_username = generate_username('My_Self_User')
+        return self.assertEqual(new_username, 'My_Self_User')
 
-    @override_settings(FEATURES={'GENERATOR_USERNAME':{'SEPARATOR':'_', 'LOWER':True, 'RANDOM': False}})
+    @override_settings(FEATURES={'USERNAME_GENERATOR':{'SEPARATOR': '_', 'LOWER': True, 'RANDOM': False}})
     def test_generate_username_with_consecutive(self):
         """
         It should return a new user with a consecutive number.
@@ -364,3 +364,14 @@ class GenerateUsernameTestCase(TestCase):
         # not neccesary append an differentiator. We expect a new user with
         # the consecutive number 6.
         return self.assertEqual(new_username, 'my_self_user_6')
+
+    @override_settings(FEATURES={'USERNAME_GENERATOR':{'SEPARATOR': '_', 'LOWER': True, 'RANDOM': True}})
+    @patch('third_party_auth.utils.UsernameGenerator.consecutive_or_random')
+    def test_generate_username_with_random(self, mock_random):
+        """
+        It should return a username with a random integer
+        at the end of the username generated.
+        """
+        mock_random.return_value = 4589
+        new_username = generate_username(self.user.username)
+        return self.assertEqual(new_username, 'my_self_user_4589')

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -9,9 +9,7 @@ from contextlib import contextmanager
 
 import django.test
 import mock
-from mock import MagicMock, patch
 from django.conf import settings
-from django.test import TestCase, override_settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from mako.template import Template
@@ -28,7 +26,6 @@ from third_party_auth.models import (
     SAMLProviderConfig
 )
 from third_party_auth.saml import EdXSAMLIdentityProvider, get_saml_idp_class
-from third_party_auth.utils import generate_username, UsernameGenerator
 
 AUTH_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
 AUTH_FEATURE_ENABLED = AUTH_FEATURES_KEY in settings.FEATURES
@@ -308,70 +305,3 @@ def simulate_running_pipeline(pipeline_target, backend, email=None, fullname=Non
     finally:
         pipeline_get.stop()
         pipeline_running.stop()
-
-
-class GenerateUsernameTestCase(TestCase):
-
-    def setUp(self):
-        self.user = User.objects.create(
-            username='my_self_user'
-        )
-        self.fullname = 'My Self User'
-
-    @override_settings(FEATURES={'USERNAME_GENERATOR':{'SEPARATOR': '_', 'LOWER': True, 'RANDOM': False}})
-    def test_separator(self):
-        """
-        The first step to generate a hinted username is the separator character of the
-        full name string. This test makes sure that we are generating a username replacing
-        all whitespaces by a character configured in settings or in site_configurations.
-        """
-        generator = UsernameGenerator()
-        username = generator.insert_separator(self.fullname)
-        return self.assertEqual(username, "My_Self_User")
-
-    @override_settings(FEATURES={"USERNAME_GENERATOR":{'SEPARATOR': '_', 'LOWER':True, 'RANDOM': False}})
-    def test_generate_username_in_lowercase(self):
-        """
-        Test if the full name that comes from insert_separator method
-        it's converted in lowercase.
-        """
-        new_username = generate_username('My_Self_User')
-        return self.assertEqual(new_username, 'my_self_user')
-
-    @override_settings(FEATURES={"USERNAME_GENERATOR":{'SEPARATOR': '_', 'LOWER': False, 'RANDOM': False}})
-    def test_generate_username_not_lowercase(self):
-        """
-        Test if the full name that comes from insert_separator method
-        is not converted in lowercase and preserves their original lowercases and
-        uppers cases.
-        """
-        new_username = generate_username('My_Self_User')
-        return self.assertEqual(new_username, 'My_Self_User')
-
-    @override_settings(FEATURES={'USERNAME_GENERATOR':{'SEPARATOR': '_', 'LOWER': True, 'RANDOM': False}})
-    def test_generate_username_with_consecutive(self):
-        """
-        It should return a new user with a consecutive number.
-        """
-        for i in range (1, 6):
-            User.objects.create(
-                username='my_self_user_{}'.format(i)
-            )
-        new_username = generate_username(self.user.username)
-        # We have 6 users: Five created in the loop with a consecutive
-        # number and another one that comes from initial setUp,
-        # the first has not consecutive number due to is
-        # not neccesary append an differentiator. We expect a new user with
-        # the consecutive number 6.
-        return self.assertEqual(new_username, 'my_self_user_6')
-
-    @override_settings(FEATURES={'USERNAME_GENERATOR':{'SEPARATOR': '_', 'LOWER': True, 'RANDOM': True}})
-    @patch('third_party_auth.utils.UsernameGenerator.consecutive_or_random')
-    def test_generate_username_with_random(self, mock_random):
-        """
-        It should return a username with a random integer
-        at the end of the username generated.
-        """
-        mock_random.return_value = 4589
-        new_username = generate_username(self.user.username)
-        return self.assertEqual(new_username, 'my_self_user_4589')

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -40,8 +40,9 @@ class UsernameGenerator(object):
         random = "%04d" % randint(0, 9999)
         return random
 
-    def generate_username(self, username):
+    def generate_username(self, fullname):
         """Utility function which generates a unique username based on the provided string."""
+        username = self.replace_separator(fullname)
         initial_username = self.process_case(username)
         user_exists = User.objects.filter(username=initial_username).exists()
 
@@ -60,8 +61,3 @@ class UsernameGenerator(object):
             counter = counter + 1
 
         return new_username
-
-    def hint_username(self, fullname):
-        """Returns a unique username based on the provided full name string."""
-        username = self.replace_separator(fullname)
-        return self.generate_username(username)

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -1,15 +1,43 @@
 from random import randint
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
 from django.contrib.auth.models import User
+
+
+class GeneratorUsername(object):
+
+    def __init__(self):
+        self.separator_character = '_'
+        self.in_lowercase = True
+        self.random = True
+
+    def separator(self, fullname):
+        username = fullname.replace(' ', self.separator_character)
+        return username
+
+    def lower(self, username):
+        if self.in_lowercase:
+            return username.lower()
+        else:
+            return username
+
+    def consecutive_or_random(self):
+        if self.random:
+            random = ''.join(["%s" % randint(0, 9) for num in range(0, 4)])
+            return random
 
 
 def generate_username(username):
     new_username = username
     user_exists = User.objects.filter(username=new_username).exists()
 
+    generator = GeneratorUsername()
+    new_username = generator.lower(username)
+
     while user_exists:
-        random = ''.join(["%s" % randint(0, 9) for num in range(0, 4)])
-        new_username = username + '_{}'.format(random)
+        subsequent_number = generator.consecutive_or_random()
+        new_username = new_username + '_{}'.format(subsequent_number)
         user_exists = User.objects.filter(username=new_username).exists()
 
     return new_username

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -2,6 +2,7 @@ from random import randint
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
+from django.conf import settings
 from django.contrib.auth.models import User
 
 
@@ -9,21 +10,27 @@ class UsernameGenerator(object):
     """Allows customize the way that the username is created based on the fullname"""
 
     def __init__(self):
-        self.separator_character = '_'
-        self.in_lowercase = True
-        self.random = True
+        default_settings = {
+            'SEPERATOR':'_',
+            'LOWER': True,
+            'RANDOM': True
+        }
+        custom_settings = configuration_helpers.get_value('GENERATOR_USERNAME', settings.FEATURES.get('GENERATOR_USERNAME', default_settings))
+        self.separator_character = custom_settings['SEPERATOR']
+        self.in_lowercase = custom_settings['LOWER']
+        self.random = custom_settings['RANDOM']
 
     def insert_separator(self, fullname):
         """
-        Allows set a custom separator character for each whitespac
-        in the fullname string. By default, all whitespaces are removed.
+        Allows set a custom separator character for each whitespace
+        in the fullname string. By default, the separator characte is underscore.
         """
         username = fullname.replace(' ', self.separator_character)
         return username
 
     def lower(self, username):
         """
-        Allows setting the username in lowercase. If not configured,
+        Allows set the username in lowercase. If value is False,
         it will take the original username that SAML providers give.
         """
         if self.in_lowercase:

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -1,0 +1,13 @@
+from random import randint
+
+from django.contrib.auth.models import User
+
+
+def generate_username(username):
+	validate_user = User.objects.filter(username=username).exists()
+	while validate_user:
+		random = ''.join(["%s" % randint(0, 9) for num in range(0, 4)])
+		new_username = username + '_{}'.format(random)
+		return new_username
+
+	return username

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -11,12 +11,12 @@ class UsernameGenerator(object):
 
     def __init__(self):
         default_settings = {
-            'SEPERATOR':'_',
+            'SEPARATOR':'_',
             'LOWER': True,
             'RANDOM': True
         }
-        custom_settings = configuration_helpers.get_value('GENERATOR_USERNAME', settings.FEATURES.get('GENERATOR_USERNAME', default_settings))
-        self.separator_character = custom_settings['SEPERATOR']
+        custom_settings = configuration_helpers.get_value('USERNAME_GENERATOR', settings.FEATURES.get('USERNAME_GENERATOR', default_settings))
+        self.separator_character = custom_settings['SEPARATOR']
         self.in_lowercase = custom_settings['LOWER']
         self.random = custom_settings['RANDOM']
 
@@ -26,9 +26,9 @@ class UsernameGenerator(object):
         in the fullname string. By default, the separator characte is underscore.
         """
         username = fullname.replace(' ', self.separator_character)
-        return username
+        return  username
 
-    def lower(self, username):
+    def process_username(self, username):
         """
         Allows set the username in lowercase. If value is False,
         it will take the original username that SAML providers give.
@@ -57,7 +57,7 @@ def generate_username(username):
     new_username = username
     user_exists = User.objects.filter(username=new_username).exists()
     generator = UsernameGenerator()
-    initial_username = generator.lower(username)
+    initial_username = generator.process_username(username)
 
     if not user_exists:
         new_username = initial_username

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -35,31 +35,27 @@ class UsernameGenerator(object):
         else:
             return username
 
-    def consecutive_or_random(self, current_number=0):
-        """
-        Returns username suffix. Based on the settings it returns
-        either the next integer or a random 4-digit number.
-        """
-        if self.random:
-            subsequent_number = ''.join(["%s" % randint(0, 9) for num in range(0, 4)])
-        else:
-            subsequent_number = current_number + 1
-
-        return subsequent_number
+    def get_random(self):
+        """Returns username a random 4-digit number."""
+        random = "%04d" % randint(0, 9999)
+        return random
 
     def generate_username(self, username):
         """Utility function which generates a unique username based on the provided string."""
-        new_username = username
-        user_exists = User.objects.filter(username=new_username).exists()
         initial_username = self.process_case(username)
+        user_exists = User.objects.filter(username=initial_username).exists()
 
         if not user_exists:
             new_username = initial_username
 
         counter = 1
         while user_exists:
-            subsequent_number = self.consecutive_or_random(counter)
-            new_username = '{}_{}'.format(initial_username, subsequent_number)
+            if self.random:
+                suffix = self.get_random()
+            else:
+                suffix = counter
+
+            new_username = '{}{}{}'.format(initial_username, self.separator_character, suffix)
             user_exists = User.objects.filter(username=new_username).exists()
             counter = counter + 1
 

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -4,10 +4,12 @@ from django.contrib.auth.models import User
 
 
 def generate_username(username):
-	validate_user = User.objects.filter(username=username).exists()
-	while validate_user:
-		random = ''.join(["%s" % randint(0, 9) for num in range(0, 4)])
-		new_username = username + '_{}'.format(random)
-		return new_username
+    new_username = username
+    user_exists = User.objects.filter(username=new_username).exists()
 
-	return username
+    while user_exists:
+        random = ''.join(["%s" % randint(0, 9) for num in range(0, 4)])
+        new_username = username + '_{}'.format(random)
+        user_exists = User.objects.filter(username=new_username).exists()
+
+    return new_username

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 
 
 class UsernameGenerator(object):
-    """It Allows to customize the way the username is created based on the fullname"""
+    """Generates a unique username based on the provided full name."""
 
     def __init__(self, generator_settings={}):
         default_settings = {
@@ -19,16 +19,16 @@ class UsernameGenerator(object):
 
     def replace_separator(self, fullname):
         """
-        Allows set a custom separator character for each whitespace
-        in the fullname string. By default, the separator characte is underscore.
+        Replaces spaces with a custom separator.
+        The default separator character is an underscore.
         """
         username = fullname.replace(' ', self.separator_character)
         return username
 
-    def process_username(self, username):
+    def process_case(self, username):
         """
-        Allows set the username in lowercase. If value is False,
-        it will take the original username that SAML providers give.
+        If in_lowercase setting is enabled, returns the string downcased,
+        otherwise returns the string unmodified.
         """
         if self.in_lowercase:
             return username.lower()
@@ -37,9 +37,8 @@ class UsernameGenerator(object):
 
     def consecutive_or_random(self, current_number=0):
         """
-        If a username already exists, a subsecuent number will be
-        append at the end of the username string. This method allows
-        if this subsecuent number be a random or consecutive.
+        Returns username suffix. Based on the settings it returns
+        either the next integer or a random 4-digit number.
         """
         if self.random:
             subsequent_number = ''.join(["%s" % randint(0, 9) for num in range(0, 4)])
@@ -49,10 +48,10 @@ class UsernameGenerator(object):
         return subsequent_number
 
     def generate_username(self, username):
-        """Util function that generates the username"""
+        """Utility function which generates a unique username based on the provided string."""
         new_username = username
         user_exists = User.objects.filter(username=new_username).exists()
-        initial_username = self.process_username(username)
+        initial_username = self.process_case(username)
 
         if not user_exists:
             new_username = initial_username
@@ -67,9 +66,6 @@ class UsernameGenerator(object):
         return new_username
 
     def hint_username(self, fullname):
-        """.
-        Returns a unique username based on the provided
-        full name string.
-        """
+        """Returns a unique username based on the provided full name string."""
         username = self.replace_separator(fullname)
         return self.generate_username(username)


### PR DESCRIPTION
# CAM-5

## Description 
This PR make a suggestion for the username based on the full name in the registration form.

## How to test

1. Configure a SAML provider such as Testshib

Step by step:

* SAML does not work with localhost, first of all, you'll need to configure ngrok or localtunnel and will give you a URL, save it for later.

* Generate a private and public key in your local computer (`openssl req -new -x509 -days 3652 -nodes -out saml.crt -keyout saml.key`)

* Go to `/admin/third_party_auth/samlconfiguration/` and add a new one.

* Once inside do the following:
            **1.** Check enable box
            **2.** Add a new site with the URL provided by ngrok (or any that you use)
            **3.** Paste the values of the saml.key and saml.cert respectively in private and public key
            **4.** In `entity id` paste again the URL provided by ngrok but add the string saml at the 
                     beginning, for example `https://saml.9dd0e842.ngrok.io`
              **5.** In `Organization info` you'll see a JSON, in `url` key paste again the URL provided by 
                        ngrok without any modifications. Save it.
* Go to `/admin/third_party_auth/samlproviderconfig/` and create a new one. Once inside do the following:
**1.** Enable the checkbox
**2.** Give a name
**3.** Select the site that you create in the previous step
**4.** Check the `visible` checkbox
**5.** In `idp-slug` give it any string without whitespaces.
**6.** In `entity ID` paste exactly this: `https://idp.testshib.org/idp/shibboleth`
**7.** In `Metadata source` paste exactly this: `https://www.testshib.org/metadata/testshib-providers.xml`
**8.** In `Entity provider type` choose `Standard SAML provider`

* By last go to `https://your_url_in_ngrok/auth/saml/metadata.xml` save this XML in your local.
* Go to `https://www.testshib.org/register.html` and upload the XML that you just saved.
* Go to `https://your_url_in_ngrok/resgister` and you'll see the button and if all is ok, you'll be able to register without any problem. Since we are using Ngrok, please reference the 4 step with the "important" note.

2. Add the new backend (`third_party_auth.saml.HintedUsernameSAMLAuthBackend`) to the list of backends immediately **after** `'third_party_auth.saml.SAMLAuthBackend'`.

3. Optional, in settings or in site_configurations add the following settings:

    If in settings:
    `FEATURES["USERNAME_GENERATOR"] = {'SEPARATOR':'_', 'LOWER':True, 'RANDOM': False}`

    If in site_configurations:
    `{"USERNAME_GENERATOR" :  {'SEPARATOR':'_', 'LOWER':True, 'RANDOM': False}}`

    SEPARATOR key only receives a string. LOWER and RANDOM only receives a bool.

    This is optional because by default takes  `_` as separator character and LOWER and RANDOM as True

    For production, these settings have to be configured in `lms.env.json`

4. **Important:** If you going to test it with a proxy such as Ngrok you have to make a mandatory small modification. In `common/third_party_auth/strategy.py` add the following method to the class `ConfigurationModelStrategy`:
    ```
    def request_port(self):
        return 443
    ```

    This a bug in Python-SAML which returns 8000 port, we need to force it to return with SSL.

## Post-approval actions
- [ ] Squash commits

## Reviewers
- [ ] @felipemontoya  
- [ ] @diegomillan
- [ ] @jagonzalr 