### PR TITLE
FIX: adding attempts as a state object to the capa problem

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -166,6 +166,7 @@ class LoncapaProblem(object):
 
         self.student_answers = state.get('student_answers', {})
         self.has_saved_answers = state.get('has_saved_answers', False)
+        self.attempts = state.get('attempts', 0)
         if 'correct_map' in state:
             self.correct_map.set_dict(state['correct_map'])
         self.done = state.get('done', False)
@@ -330,7 +331,8 @@ class LoncapaProblem(object):
                 'has_saved_answers': self.has_saved_answers,
                 'correct_map': self.correct_map.get_dict(),
                 'input_state': self.input_state,
-                'done': self.done}
+                'done': self.done,
+                'attempts': self.attempts}
 
     def get_max_score(self):
         """

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -377,6 +377,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
             'has_saved_answers': self.has_saved_answers,
             'input_state': self.input_state,
             'seed': self.seed,
+            'attempts': self.attempts,
         }
 
     def set_state_from_lcp(self):
@@ -390,6 +391,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         self.student_answers = lcp_state['student_answers']
         self.has_saved_answers = lcp_state['has_saved_answers']
         self.seed = lcp_state['seed']
+        self.attempts = lcp_state['attempts']
 
     def set_last_submission_time(self):
         """
@@ -1252,7 +1254,8 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
 
         try:
             correct_map = self.lcp.grade_answers(answers)
-            self.attempts = self.attempts + 1
+            self.lcp.attempts = self.lcp.attempts + 1
+            self.attempts = self.lcp.attempts
             self.lcp.done = True
             self.set_state_from_lcp()
             self.set_score(self.score_from_lcp())


### PR DESCRIPTION
Adding the attempts field to the actual capa problem list for state keeping