### PR TITLE
Add dynamic fragment in order to response to button's events

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/teams_features.js
+++ b/lms/djangoapps/teams/static/teams/js/teams_features.js
@@ -1,29 +1,65 @@
 /* Javascript for StudioView. */
 (function(define) {
     'use strict';
+
+    var xblock;
+
+    function createRocketChatDiscussion(data){
+        var style = $(data)[0];
+        xblock = $(data).find(".xblock-student_view-rocketc");
+        $("head").append(style);
+         $(".discussion-module").hide();
+        if ($("div.discussion-module")[0] && !$(".page-content-main").find(".xblock-student_view-rocketc")[0]){
+            $(".team-profile").find(".page-content-main").append(xblock);
+        }else if ($(".page-content-main").find(".xblock-student_view-rocketc")[0]){
+            $(".xblock-student_view-rocketc").replaceWith(xblock);
+        }
+
+    };
+
+    function loadRocketChat(url){
+        $.ajax({
+            url: url,
+            success: createRocketChatDiscussion
+        });
+    }
+
+    function actionsReloadRocketChat(url){
+        $( ".join-team .action" ).unbind().click(function() {
+            loadRocketChat(url);
+        });
+        $( ".create-team .action" ).unbind().click(function() {
+            loadRocketChat(url);
+        });
+        $( ".action-primary" ).unbind().click(function() {
+            loadRocketChat(url);
+        });
+    }
+
     define(['jquery'],
 
         function($) {
 
-            var xblock = $(".xblock-student_view-rocketc");
-            $(".hidden-rocket-chat").hide()
-
             $(window).load(function() {
 
                 $(".discussion-module").hide();
-                $(".team-profile").find(".page-content-main").append(xblock);
+                var baseUrl = $(".container").attr("data-url");
+                var url = baseUrl + "rocket-chat-discussion";
+                loadRocketChat(url);
+                actionsReloadRocketChat(url);
 
-                var targetNode = $(".teams-content")[0];
+                var targetNode = $(".view-in-course")[0];
 
                 // Options for the observer (which mutations to observe)
                 var config = {subtree : true, attributes: true}
 
                 // Callback function to execute when mutations are observed
                 function fnHandler () {
-                    if($("div.discussion-module")[0] && !$(".page-content-main").find(".xblock-student_view-rocketc")[0]){
+                    if ($("div.discussion-module")[0] && !$(".page-content-main").find(".xblock-student_view-rocketc")[0]){
                         $(".discussion-module").hide();
-                        $(".team-profile").find(".page-content-main").append(xblock);   
+                        $(".team-profile").find(".page-content-main").append(xblock);
                     }
+                    actionsReloadRocketChat(url);
                 }
                 // Create an observer instance linked to the callback function
                 var observer = new MutationObserver(fnHandler);
@@ -34,4 +70,5 @@
             });
 
         });
+
 }).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/views/rocket_chat_discussion.js
+++ b/lms/djangoapps/teams/static/teams/js/views/rocket_chat_discussion.js
@@ -1,0 +1,15 @@
+/* Javascript for RocketChat- discussions */
+(function(define) {
+    'use strict';
+    define(['jquery'],
+
+        function($) {
+
+            var xblock = $(".xblock-student_view-rocketc");
+            var style = $("style");
+            $( "body" ).empty();
+            $( "body" ).append(xblock);
+            $( "body" ).append(style);
+
+        });
+}).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/templates/teams/rocket_chat_discussion.html
+++ b/lms/djangoapps/teams/templates/teams/rocket_chat_discussion.html
@@ -1,0 +1,16 @@
+## mako
+
+<%!
+import json
+import waffle
+ %>
+
+%if waffle.switch_is_active('rocket_chat_discussions') and not fragment.discussion_is_available():
+    <% frag = fragment.get_fragment() %>
+    %if frag:
+        ${frag.head_html() |n}
+        <div class="hidden-rocket-chat">
+            ${frag.body_html() |n }
+        </div>
+    %endif
+%endif

--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -27,7 +27,7 @@ from openedx.core.djangolib.js_utils import (
 
 <%include file="/courseware/course_navigation.html" args="active_page='teams'" />
 
-<div class="container">
+<div class="container" data-url="${ teams_base_url }">
     <div class="teams-wrapper">
         <main id="main" aria-label="Content" tabindex="-1">
             <section class="teams-content">
@@ -35,18 +35,6 @@ from openedx.core.djangolib.js_utils import (
         </main>
     </div>
 </div>
-
-<%block name="footer_extra">
-%if waffle.switch_is_active('rocket_chat_discussions') and not fragment.discussion_is_available():
-    <% frag = fragment.get_fragment() %>
-    %if frag:
-        ${frag.head_html() |n}
-        <div class="hidden-rocket-chat" style="display: none;">
-            ${frag.body_html() |n}
-        </div>
-    %endif
-%endif
-</%block>
 
 <%block name="js_extra">
 
@@ -70,7 +58,7 @@ from openedx.core.djangolib.js_utils import (
         teamsBaseUrl: '${teams_base_url | n, js_escaped_string}'
     });
 </%static:require_module>
-%if waffle.switch_is_active('rocket_chat_discussions') and not fragment.discussion_is_available():
+%if waffle.switch_is_active('rocket_chat_discussions'):
     <%static:require_module module_name="teams/js/teams_features" class_name="TeamsView" />
 %endif
 </%block>

--- a/lms/djangoapps/teams/urls.py
+++ b/lms/djangoapps/teams/urls.py
@@ -5,8 +5,9 @@ Defines the URL routes for this app.
 from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
-from .views import TeamsDashboardView
+from .views import TeamsDashboardView, TeamsRocketChatView
 
 urlpatterns = [
-    url(r"^$", login_required(TeamsDashboardView.as_view()), name="teams_dashboard")
+    url(r"^$", login_required(TeamsDashboardView.as_view()), name="teams_dashboard"),
+    url(r"^rocket-chat-discussion", login_required(TeamsRocketChatView.as_view()), name="teams_rocket_chat_discussion")
 ]

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -165,7 +165,6 @@ class TeamsDashboardView(GenericAPIView):
             "countries": list(countries),
             "disable_courseware_js": True,
             "teams_base_url": reverse('teams_dashboard', request=request, kwargs={'course_id': course_id}),
-            "fragment": ModifyTeams(request, user, course_key),
         }
         return render_to_response("teams/teams.html", context)
 
@@ -1265,3 +1264,32 @@ class MembershipDetailView(ExpandableFieldViewMixin, GenericAPIView):
             return Response(status=status.HTTP_204_NO_CONTENT)
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+class TeamsRocketChatView(GenericAPIView):
+    """
+    RocketChat view
+    """
+
+    def get(self, request, course_id):
+        """
+        Renders the Xblock RocketChat
+
+        Raises a 404 if the course specified by course_id does not exist, the
+        user is not registered for the course, or the teams feature is not enabled.
+        """
+        course_key = CourseKey.from_string(course_id)
+        course = get_course_with_access(request.user, "load", course_key)
+
+        if not is_feature_enabled(course):
+            raise Http404
+
+        if not CourseEnrollment.is_enrolled(request.user, course.id) and \
+                not has_access(request.user, 'staff', course, course.id):
+            raise Http404
+
+        user = request.user
+
+        context = {
+            "fragment": ModifyTeams(request, user, course_key),
+        }
+        return render_to_response("teams/rocket_chat_discussion.html", context)

--- a/lms/static/lms/js/build.js
+++ b/lms/static/lms/js/build.js
@@ -46,6 +46,7 @@
             'support/js/certificates_factory',
             'support/js/enrollment_factory',
             'support/js/manage_user_factory',
+            'teams/js/views/rocket_chat_discussion',
             'teams/js/teams_tab_factory',
             'teams/js/teams_features',
             'js/dateutil_factory'


### PR DESCRIPTION
## Description
This branch adds a new view in order to load it dynamically in team's page, this allows to reload the rocketchat xblock with events.

## Reviewers 
- [ ] @jfavellar90 
- [x] @nicovanniekerk 
- [ ] @diegomillan 

### Notes
- This fixes the error 5 from that list https://docs.google.com/document/d/1cnjZUpkDEYq7gZ76gVW4ODUJr2KMMWrSiSsoY946FYg/edit#