### PR TITLE
Creation teams via CSV

### DIFF
--- a/lms/djangoapps/teams/api_urls.py
+++ b/lms/djangoapps/teams/api_urls.py
@@ -11,7 +11,8 @@ from .views import (
     TeamsDetailView,
     TeamsListView,
     TopicDetailView,
-    TopicListView
+    TopicListView,
+    CreateTeams
 )
 
 TEAM_ID_PATTERN = r'(?P<team_id>[a-z\d_-]+)'
@@ -55,5 +56,12 @@ urlpatterns = [
         ),
         MembershipDetailView.as_view(),
         name="team_membership_detail"
-    )
+    ),
+    url(
+        r'^create_teams/{course_id_pattern}$'.format(
+            course_id_pattern=settings.COURSE_ID_PATTERN,
+        ),
+        CreateTeams.as_view(),
+        name="create_teams"
+    ),
 ]

--- a/lms/djangoapps/teams/static/teams/js/teams_features.js
+++ b/lms/djangoapps/teams/static/teams/js/teams_features.js
@@ -61,28 +61,26 @@
     };
 
     function buttonAddMembers(staff, url){
-        var button = $("<button class='action'>Add Members</button>");
+        var button = $("<button class='action action-primary'>Add Members</button>");
         var input = $("<input type='file' name='fileUpload' style='display: none;'accept='text/csv'/>")
         if(!$(".page-header-secondary").children()[0] && staff){
             $(".page-header-secondary").append(input);
             $(".page-header-secondary").append(button);
-            uploadFile(input, url);
+
+            input.fileupload({
+                url: url,
+                done:function(){
+                    $(".page-header-secondary").empty();
+                    buttonAddMembers(staff, url);
+                },
+                fail: function(e, data){
+                }
+            });
 
             button.click(function(){
                 input.click();
             });
         }
-    }
-
-    function uploadFile(input, url){
-        input.fileupload({
-            url: url,
-            done:function(){
-                $(".page-header-secondary").append($("<div>Success</div>"));
-            },
-            fail: function(e, data){
-            }
-        });
     }
 
     function loadjs(url) {

--- a/lms/djangoapps/teams/static/teams/js/teams_features.js
+++ b/lms/djangoapps/teams/static/teams/js/teams_features.js
@@ -38,7 +38,7 @@
         $( ".action-primary" ).unbind().click(function() {
             createRocketChatDiscussion(urlRocketChat);
         });
-    }
+    };
 
     function loadUserTeam(options){
         var data = {"course_id": options.courseID, "username": options.userInfo.username}
@@ -49,7 +49,7 @@
                 teams = data;
             }
         });
-    }
+    };
 
     function removeBrowseTab(teams){
         if (teams.count == 1){
@@ -58,14 +58,51 @@
             $("#tab-0").addClass("is-active");
             $("#tabpanel-my-teams").removeClass("is-hidden");
         }
+    };
+
+    function buttonAddMembers(staff, url){
+        var button = $("<button class='action'>Add Members</button>");
+        var input = $("<input type='file' name='fileUpload' style='display: none;'accept='text/csv'/>")
+        if(!$(".page-header-secondary").children()[0] && staff){
+            $(".page-header-secondary").append(input);
+            $(".page-header-secondary").append(button);
+            uploadFile(input, url);
+
+            button.click(function(){
+                input.click();
+            });
+        }
+    }
+
+    function uploadFile(input, url){
+        input.fileupload({
+            url: url,
+            done:function(){
+                $(".page-header-secondary").append($("<div>Success</div>"));
+            },
+            fail: function(e, data){
+            }
+        });
+    }
+
+    function loadjs(url) {
+        $('<script>')
+            .attr('type', 'text/javascript')
+            .attr('src', url)
+            .appendTo("body");
     }
 
     define(['jquery'],
 
         function($) {
 
+            loadjs('/static/js/vendor/jQuery-File-Upload/js/vendor/jquery.ui.widget.js');
+            loadjs('/static/js/vendor/jQuery-File-Upload/js/jquery.fileupload.js');
+
             return function(options){
                 var urlRocketChat = "/xblock/"+options.rocketChatLocator;
+                var urlApiCreateTeams = options.teamsCreateUrl;
+                var staff = options.userInfo.staff;
                 teams = options.userInfo.teams;
 
                 $(window).load(function() {
@@ -75,6 +112,7 @@
                     createRocketChatDiscussion(urlRocketChat);
                     actionsButtons(urlRocketChat);
                     removeBrowseTab(teams);
+                    buttonAddMembers(staff, urlApiCreateTeams);
 
                     var targetNode = $(".view-in-course")[0];
 
@@ -90,6 +128,7 @@
                         loadUserTeam(options);
                         actionsButtons(urlRocketChat);
                         removeBrowseTab(teams);
+                        buttonAddMembers(staff, urlApiCreateTeams);
                     }
                     // Create an observer instance linked to the callback function
                     var observer = new MutationObserver(fnHandler);

--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -65,6 +65,7 @@ from openedx.core.djangolib.js_utils import (
         userInfo: ${user_info | n, dump_js_escaped_json},
         teamsUrl: '${teams_url | n, js_escaped_string}',
         teamsBaseUrl: '${teams_base_url | n, js_escaped_string}',
+        teamsCreateUrl: '${teams_create_url | n, js_escaped_string}',
         rocketChatLocator: '${rocket_chat_locator | n, js_escaped_string}'
     });
     </%static:require_module>

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -169,6 +169,7 @@ class TeamsDashboardView(GenericAPIView):
             "disable_courseware_js": True,
             "teams_base_url": reverse('teams_dashboard', request=request, kwargs={'course_id': course_id}),
             "rocket_chat_locator": ModifyTeams(request, user, course_key).get_rocket_chat_locator(),
+            "teams_create_url": reverse('create_teams', args= [course_id]),
         }
         return render_to_response("teams/teams.html", context)
 
@@ -1270,15 +1271,15 @@ class MembershipDetailView(ExpandableFieldViewMixin, GenericAPIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
 class CreateTeams(GenericAPIView):
-
+    """
+        This class allows to create a team and add a user from a CSV file
+    """
     def post(self, request, course_id):
 
         file = request.FILES
-        if 'file' in file:
-            self.handle_uploaded_file(file['file'], course_id)
+        if 'fileUpload' in file:
+            self.handle_uploaded_file(file['fileUpload'], course_id)
             return Response(status=status.HTTP_204_NO_CONTENT)
-        else:
-            form = UploadFileForm()
         return Response(status=status.HTTP_404_NOT_FOUND)
 
     def handle_uploaded_file(self, file, course_id):

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -1276,6 +1276,9 @@ class CreateTeams(GenericAPIView):
     """
     def post(self, request, course_id):
 
+        if not has_team_api_access(request.user, course_id) :
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
         file = request.FILES
         if 'fileUpload' in file:
             self.handle_uploaded_file(file['fileUpload'], course_id)

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -1,9 +1,11 @@
 """HTTP endpoints for the Teams API."""
 
 import logging
+import csv
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.db.models import Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.http import Http404
@@ -51,6 +53,7 @@ from .serializers import (
 )
 from .teams_features import ModifyTeams
 from .utils import emit_team_event
+from .errors import AlreadyOnTeamInCourse
 
 TEAM_MEMBERSHIPS_PER_PAGE = 2
 TOPICS_PER_PAGE = 12
@@ -1265,3 +1268,68 @@ class MembershipDetailView(ExpandableFieldViewMixin, GenericAPIView):
             return Response(status=status.HTTP_204_NO_CONTENT)
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+class CreateTeams(GenericAPIView):
+
+    def post(self, request, course_id):
+
+        file = request.FILES
+        if 'file' in file:
+            self.handle_uploaded_file(file['file'], course_id)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        else:
+            form = UploadFileForm()
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def handle_uploaded_file(self, file, course_id):
+
+        reader = csv.reader(file)
+        course_key = CourseKey.from_string(course_id)
+        course_module = modulestore().get_course(course_key)
+        topics = get_alphabetical_topics(course_module)
+        topic_ids = {}
+
+        for topic in topics:
+            topic_ids[topic["id"]] = topic["id"]
+
+        for row in reader:
+
+            if not self.get_from_list(row, 1) in topic_ids:
+                continue
+            try:
+                user = User.objects.get(Q(username=row[0]) | Q(email=row[0]))
+            except User.DoesNotExist:
+                continue
+            if not CourseEnrollment.is_enrolled(user, course_key):
+                continue
+            try:
+                team = CourseTeam.objects.get(Q(topic_id=self.get_from_list(row, 1)) & Q(name=self.get_from_list(row, 2)) & Q(course_id=course_key))
+            except CourseTeam.DoesNotExist:
+                data = {
+                    'last_activity_at': '',
+                    'topic_id': self.get_from_list(row, 1),
+                    'name': self.get_from_list(row, 2),
+                    'description': self.get_from_list(row, 3),
+                    'course_id': course_id,
+                    'language': self.get_from_list(row, 4),
+                    'country': self.get_from_list(row, 5),
+                    'membership': [],
+                    'id': None,
+                    'date_created': ''
+                }
+                field_errors = {}
+                serializer = CourseTeamCreationSerializer(data=data)
+                add_serializer_errors(serializer, data, field_errors)
+                team = serializer.save()
+            try:
+                team.add_user(user)
+            except AlreadyOnTeamInCourse:
+                membership = CourseTeamMembership.objects.get(user__username=user.username)
+                membership.delete()
+                team.add_user(user)
+
+    def get_from_list(self, values, index):
+        try:
+            return values[index]
+        except IndexError:
+            return ''


### PR DESCRIPTION
## Description 
This changes allows to use a new API to create teams via CSV file. Adding a new button to upload a file in team page (only a staff user can see it). This raises 404 if a wrong file was selected.

## Reviewers 
- [ ] @jfavellar90 
- [ ] @diegomillan 
- [ ] @nicovanniekerk 