### PR TITLE
students can't change team themselves

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/teams_features.js
+++ b/lms/djangoapps/teams/static/teams/js/teams_features.js
@@ -3,7 +3,6 @@
     'use strict';
 
     var xblock;
-    var teams;
 
     function createRocketChatDiscussion(urlRocketChat){
 
@@ -46,28 +45,30 @@
             url: options.teamsUrl,
             data: data,
             success: function(data){
-                teams = data;
+                if(data.count == 1){
+                    removeBrowseTab();
+                }
             }
         });
     };
 
-    function removeBrowseAndButtons(staff, teamsLocked){
+    function removeBrowseTab(){
+        $("#tab-1").remove();
+        $("#tabpanel-browse").remove();
+        $("#tab-0").addClass("is-active");
+        $("#tabpanel-my-teams").removeClass("is-hidden");
+    };
+
+    function removeBrowseAndButtons(staff, teamsLocked, options){
         if (teamsLocked && !staff){
             // Remove browse
-            $("#tab-1").remove();
-            $("#tabpanel-browse").remove();
-            $("#tab-0").addClass("is-active");
-            $("#tabpanel-my-teams").removeClass("is-hidden");
+            removeBrowseTab();
             // remove join and leave button
             $(".join-team .action-primary").remove();
             $(".page-content-secondary .leave-team").remove();
 
-        }else if(teams.count == 1 && !staff){
-            // Remove browse
-            $("#tab-1").remove();
-            $("#tabpanel-browse").remove();
-            $("#tab-0").addClass("is-active");
-            $("#tabpanel-my-teams").removeClass("is-hidden");
+        }else if(!staff){
+            loadUserTeam(options);
         };
     };
 
@@ -112,8 +113,7 @@
                 var urlRocketChat = "/xblock/"+options.rocketChatLocator;
                 var urlApiCreateTeams = options.teamsCreateUrl;
                 var staff = options.userInfo.staff;
-                var teamsLocked = (options.teamsLocked == "true");
-                teams = options.userInfo.teams;
+                var teamsLocked = JSON.parse(options.teamsLocked);
 
                 $(window).load(function() {
 
@@ -122,7 +122,7 @@
                     createRocketChatDiscussion(urlRocketChat);
                     actionsButtons(urlRocketChat);
                     buttonAddMembers(staff, urlApiCreateTeams);
-                    removeBrowseAndButtons(staff, teamsLocked);
+                    removeBrowseAndButtons(staff, teamsLocked, options);
 
                     var targetNode = $(".view-in-course")[0];
 
@@ -135,10 +135,9 @@
                             $(".discussion-module").hide();
                             $(".team-profile").find(".page-content-main").append(xblock);
                         }
-                        loadUserTeam(options);
                         actionsButtons(urlRocketChat);
                         buttonAddMembers(staff, urlApiCreateTeams);
-                        removeBrowseAndButtons(staff, teamsLocked);
+                        removeBrowseAndButtons(staff, teamsLocked, options);
                     }
                     // Create an observer instance linked to the callback function
                     var observer = new MutationObserver(fnHandler);

--- a/lms/djangoapps/teams/static/teams/js/teams_features.js
+++ b/lms/djangoapps/teams/static/teams/js/teams_features.js
@@ -51,13 +51,24 @@
         });
     };
 
-    function removeBrowseTab(teams){
-        if (teams.count == 1){
+    function removeBrowseAndButtons(staff, teamsLocked){
+        if (teamsLocked && !staff){
+            // Remove browse
             $("#tab-1").remove();
             $("#tabpanel-browse").remove();
             $("#tab-0").addClass("is-active");
             $("#tabpanel-my-teams").removeClass("is-hidden");
-        }
+            // remove join and leave button
+            $(".join-team .action-primary").remove();
+            $(".page-content-secondary .leave-team").remove();
+
+        }else if(teams.count == 1 && !staff){
+            // Remove browse
+            $("#tab-1").remove();
+            $("#tabpanel-browse").remove();
+            $("#tab-0").addClass("is-active");
+            $("#tabpanel-my-teams").removeClass("is-hidden");
+        };
     };
 
     function buttonAddMembers(staff, url){
@@ -101,6 +112,7 @@
                 var urlRocketChat = "/xblock/"+options.rocketChatLocator;
                 var urlApiCreateTeams = options.teamsCreateUrl;
                 var staff = options.userInfo.staff;
+                var teamsLocked = (options.teamsLocked == "true");
                 teams = options.userInfo.teams;
 
                 $(window).load(function() {
@@ -109,8 +121,8 @@
 
                     createRocketChatDiscussion(urlRocketChat);
                     actionsButtons(urlRocketChat);
-                    removeBrowseTab(teams);
                     buttonAddMembers(staff, urlApiCreateTeams);
+                    removeBrowseAndButtons(staff, teamsLocked);
 
                     var targetNode = $(".view-in-course")[0];
 
@@ -125,8 +137,8 @@
                         }
                         loadUserTeam(options);
                         actionsButtons(urlRocketChat);
-                        removeBrowseTab(teams);
                         buttonAddMembers(staff, urlApiCreateTeams);
+                        removeBrowseAndButtons(staff, teamsLocked);
                     }
                     // Create an observer instance linked to the callback function
                     var observer = new MutationObserver(fnHandler);

--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -66,6 +66,7 @@ from openedx.core.djangolib.js_utils import (
         teamsUrl: '${teams_url | n, js_escaped_string}',
         teamsBaseUrl: '${teams_base_url | n, js_escaped_string}',
         teamsCreateUrl: '${teams_create_url | n, js_escaped_string}',
+        teamsLocked: '${teams_locked | n, dump_js_escaped_json}',
         rocketChatLocator: '${rocket_chat_locator | n, js_escaped_string}'
     });
     </%static:require_module>


### PR DESCRIPTION
## Description
Block the user ability to join or leave a team, hide join and leave buttons. This uses  an advanced setting to lock a team, If this is true a user can not leave or join into the team, but the staff can

## Reviewers 
- [x] @jfavellar90 
- [ ] @nicovanniekerk 
- [ ] @diegomillan 
