### PR TITLE
Increase students files upload size limit to 20MB.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -699,7 +699,7 @@ derived_collection_entry('DEFAULT_TEMPLATE_ENGINE', 'DIRS')
 ###############################################################################################
 
 AUTHENTICATION_BACKENDS = ['openedx.core.djangoapps.oauth_dispatch.dot_overrides.validators.EdxRateLimitedAllowAllUsersModelBackend']
-STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
+STUDENT_FILEUPLOAD_MAX_SIZE = 20 * 1000 * 1000  # 20 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
 # Set request limits for maximum size of a request body and maximum number of GET/POST parameters. (>=Django 1.10)


### PR DESCRIPTION
## Reviewer
- [ ] @andrey-canon 