### PR TITLE
PE-399 Support a different slug name from backend name 

### DIFF
--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -29,13 +29,16 @@ class ConfigurationModelStrategy(DjangoStrategy):
             setting 'name' is configured via LTIProviderConfig.
         """
         if isinstance(backend, OAuthAuth):
-            provider_config = OAuth2ProviderConfig.current(backend.name)
-            if not provider_config.enabled_for_current_site:
-                raise Exception("Can't fetch setting of a disabled backend/provider.")
-            try:
-                return provider_config.get_setting(name)
-            except KeyError:
-                pass
+            oauth2_slugs = OAuth2ProviderConfig.key_values('provider_slug', flat=True)
+            for oauth2_slug in oauth2_slugs:
+                provider = OAuth2ProviderConfig.current(oauth2_slug)
+                if provider.enabled_for_current_site and provider.backend_name == backend.name:
+                    try:
+                        return provider.get_setting(name)
+                    except KeyError:
+                        pass
+                elif not provider.enabled_for_current_site and provider.backend_name == backend.name:
+                    raise Exception("Can't fetch setting of a disabled backend/provider.")
 
         # special case handling of login error URL if we're using a custom auth entry point:
         if name == 'LOGIN_ERROR_URL':


### PR DESCRIPTION
##Description 
Get the provider by using the provider_slug in order to support a slug name different from backend_name