### PR TITLE
MIGRATION-38 - Adding custom course experience fragments.

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1105,6 +1105,11 @@ COURSE_ENROLLMENT_MODES = ENV_TOKENS.get('COURSE_ENROLLMENT_MODES', COURSE_ENROL
 ############## Settings for Writable Gradebook  #########################
 WRITABLE_GRADEBOOK_URL = ENV_TOKENS.get('WRITABLE_GRADEBOOK_URL', WRITABLE_GRADEBOOK_URL)
 
+############## Settings for use custom course experience fragments. ##############
+# This setting is used to enable the custom proversity fragments stored in
+# openedx/features/course_experience/templates/course_experience/*-proversity.html
+CUSTOM_COURSE_EXPERIENCE_FRAGMENTS = False
+
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3479,6 +3479,11 @@ FERNET_KEYS = [
 # Maximum number of rows to fetch in XBlockUserStateClient calls. Adjust for performance
 USER_STATE_BATCH_SIZE = 5000
 
+############## Settings for use custom course experience fragments. ##############
+# This setting is used to enable the custom proversity fragments stored in
+# openedx/features/course_experience/templates/course_experience/*-proversity.html
+CUSTOM_COURSE_EXPERIENCE_FRAGMENTS = False
+
 ############## Plugin Django Apps #########################
 
 from openedx.core.djangoapps.plugins import plugin_apps, plugin_settings, constants as plugin_constants

--- a/openedx/features/course_experience/templates/course_experience/course-dates-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/course-dates-fragment-proversity.html
@@ -1,0 +1,20 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+
+<%!
+from django.utils.translation import ugettext as _
+%>
+
+<h3>${_("Important Course Dates")}</h3>
+## Should be organized by date, last date appearing at the bottom
+
+% for course_date in course_date_blocks:
+<%include file="dates-summary.html" args="course_date=course_date" />
+% endfor
+
+<%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">
+    DateUtilFactory.transform('.localized-datetime');
+</%static:require_module_async>

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment-proversity.html
@@ -1,0 +1,87 @@
+## mako
+
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+
+<%!
+import json
+
+from django.conf import settings
+from django.utils.translation import ugettext as _
+from django.template.defaultfilters import escapejs
+from django.core.urlresolvers import reverse
+
+from django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
+from openedx.core.djangolib.markup import HTML
+from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG, SHOW_REVIEWS_TOOL_FLAG
+from openedx.features.learner_analytics import ENABLE_DASHBOARD_TAB
+%>
+
+<%
+real_user = getattr(user, 'real_user', user)
+username = real_user.username
+profile_image_url = get_profile_image_urls_for_user(real_user)['medium']
+%>
+
+<section role="courseware">
+    % if ENABLE_DASHBOARD_TAB.is_enabled(course_key):
+        ${static.renderReact(
+        component="UpsellExperimentModal",
+        id="upsell-modal",
+        props={},
+    )}
+    % endif
+    <div class="container no-border">
+        <h1>${course.display_name_with_default}</h1>
+        <div class="btn-center">
+            % if resume_course_url:
+            <a href="${resume_course_url}" class="btn btn-lg btn-default">
+                % if has_visited_course:
+                ${_("Resume Course")}
+                <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+                % else:
+                ${_("Start Course")}
+                % endif
+            </a>
+            % endif
+        </div>
+        <div class="grid">
+            <div class="items dates">
+                <div>
+                    <i class="fa fa-calendar" aria-hidden="true"></i>
+                    ${HTML(dates_fragment.body_html())}
+                </div>
+            </div>
+            <div class="items handouts">
+                <div>
+                    % if handouts_html:
+                    <i class="fa fa-paper-plane" aria-hidden="true"></i>
+                    <h3>${_("Course Handouts")}</h3>
+                    ${HTML(handouts_html)}
+                    % endif
+                </div>
+            </div>
+        </div>
+        <h2>${_("Summary")}</h2>
+
+        ${HTML(outline_fragment.body_html())}
+    </div>
+</section>
+
+
+<%static:webpack entry="CourseHome">
+    new CourseHome({
+        courseRunKey: "${course_key | n, js_escaped_string}",
+        resumeCourseLink: ".action-resume-course",
+        courseToolLink: ".course-tool-link",
+        goalApiUrl: "${goal_api_url | n, js_escaped_string}",
+        username: "${username | n, js_escaped_string}",
+        courseId: "${course.id | n, js_escaped_string}",
+    });
+</%static:webpack>
+
+<%static:webpack entry="Enrollment">
+    new CourseEnrollment('.enroll-btn', '${course_key | n, js_escaped_string}');
+</%static:webpack>

--- a/openedx/features/course_experience/templates/course_experience/course-messages-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/course-messages-fragment-proversity.html
@@ -1,0 +1,41 @@
+## mako
+
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+
+<%!
+from django.utils.translation import get_language_bidi
+from django.utils.translation import ugettext as _
+
+from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.core.djangolib.markup import HTML
+from openedx.features.course_experience import CourseHomeMessages
+%>
+
+<%
+is_rtl = get_language_bidi()
+%>
+
+% if course_home_messages:
+    % for message in course_home_messages:
+        <div class="course-message grid-manual">
+            % if not is_rtl:
+                <img class="message-author col col-2" src="${static.url(image_src)}" />
+            % endif
+            <div class="message-content col col-9">
+                ${HTML(message.message_html)}
+            </div>
+            % if is_rtl:
+                <img class="message-author col col-2" src="${static.url(image_src)}" />
+            % endif
+        </div>
+    % endfor
+% endif
+
+<%static:webpack entry="CourseGoals">
+    new CourseGoals({
+        goalApiUrl: "${goal_api_url | n, js_escaped_string}",
+        courseId: "${course_id | n, js_escaped_string}",
+        username: "${username | n, js_escaped_string}",
+    });
+</%static:webpack>

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment-proversity.html
@@ -1,0 +1,216 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+
+<%!
+from datetime import date
+
+from django.utils.translation import ugettext as _
+
+from openedx.core.djangolib.markup import HTML, Text
+
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+%>
+
+<%
+self.real_user = getattr(user, 'real_user', user)
+username = self.real_user.username
+profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+%>
+
+<main role="main" class="course-outline hidden" id="main" tabindex="-1">
+    % if blocks.get('children'):
+    <ol class="block-tree" role="tree">
+        % for section in blocks.get('children'):
+        <li aria-expanded="true" class="outline-item focusable section" id="${ section['id'] }" role="treeitem"
+            tabindex="0">
+            <div class="section-name">
+                <h3>${ section['display_name'] }</h3>
+            </div>
+
+            <ol class="outline-item focusable" role="group" tabindex="0">
+                % for subsection in section.get('children', []):
+                <li class="subsection ${ 'current' if subsection['resume_block'] else '' }" role="treeitem"
+                    tabindex="-1" aria-expanded="true">
+                    <a class="outline-item focusable" href="${ subsection['lms_web_url'] }" id="${ subsection['id'] }">
+                        <div class="subsection-text">
+                            ## Subsection title
+                            <span class="subsection-title"></span>
+                            % if subsection['id'] in gated_content:
+                            % if gated_content[subsection['id']]['completed_prereqs']:
+                            <span class="menu-icon icon fa fa-unlock" aria-hidden="true">
+                            </span>
+                            <span class="subsection-title-name">
+                                ${ subsection['display_name'] }
+                            </span>
+                            <span class="sr">&nbsp;${_("Unlocked")}</span>
+                            % else:
+                            <span class="menu-icon icon fa fa-lock" aria-hidden="true">
+                            </span>
+                            <span class="subsection-title-name">
+                                ${ subsection['display_name'] }
+                            </span>
+                            <span class="details">
+                                ${ _("(Prerequisite required)") }
+                            </span>
+                            % endif
+                            % else:
+                            <span class="subsection-title-name">
+                                ${ subsection['display_name'] }
+                            </span>
+                            % endif
+                            <div class="details">
+                                ## There are behavior differences between rendering of subsections which have
+                                ## exams (timed, graded, etc) and those that do not.
+                                ##
+                                ## Exam subsections expose exam status message field as well as a status icon
+                                <%
+                                                if subsection.get('due') is None:
+                                                    # examples: Homework, Lab, etc.
+                                                    data_string = subsection.get('format')
+                                                else:
+                                                    if 'special_exam_info' in subsection:
+                                                        data_string = _('due {date}')
+                                                    else:
+                                                        data_string = _("{subsection_format} due {{date}}").format(subsection_format=subsection.get('format'))
+                                            %>
+                                % if subsection.get('format') or 'special_exam_info' in subsection:
+                                <span class="subtitle">
+                                    % if 'special_exam' in subsection:
+                                    ## Display the exam status icon and status message
+                                    <span
+                                        class="menu-icon icon fa ${subsection['special_exam_info'].get('suggested_icon', 'fa-pencil-square-o')} ${subsection['special_exam_info'].get('status', 'eligible')}"
+                                        aria-hidden="true"></span>
+                                    <span class="subtitle-name">
+                                        ${subsection['special_exam_info'].get('short_description', '')}
+                                    </span>
+
+                                    ## completed exam statuses should not show the due date
+                                    ## since the exam has already been submitted by the user
+                                    % if not subsection['special_exam_info'].get('in_completed_state', False):
+                                    <span class="localized-datetime subtitle-name"
+                                        data-datetime="${subsection.get('due')}" data-string="${data_string}"
+                                        data-timezone="${user_timezone}" data-language="${user_language}"></span>
+                                    % endif
+                                    % else:
+                                    ## non-graded section, we just show the exam format and the due date
+                                    ## this is the standard case in edx-platform
+                                    <span class="localized-datetime subtitle-name"
+                                        data-datetime="${subsection.get('due')}" data-string="${data_string}"
+                                        data-timezone="${user_timezone}" data-language="${user_language}"></span>
+
+                                    % if 'graded' in subsection and subsection['graded']:
+                                    <span class="menu-icon icon fa fa-pencil-square-o" aria-hidden="true"></span>
+                                    <span class="sr">${_("This content is graded")}</span>
+                                    % endif
+                                    % endif
+                                </span>
+                                % endif
+                            </div> <!-- /details -->
+                        </div> <!-- /subsection-text -->
+                        <div class="subsection-actions">
+                            ## Resume button (if last visited section)
+                            % if subsection['resume_block']:
+                            <span class="sr-only">${ _("This is your last visited course section.") }</span>
+                            <span class="resume-right">
+                                <b>${ _("Resume Course") }</b>
+                                <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>
+                            </span>
+                            %endif
+                        </div>
+                    </a>
+                </li>
+                % endfor
+            </ol>
+        </li>
+        % endfor
+    </ol>
+    % endif
+</main>
+
+% if blocks.get('children'):
+
+<ul class="course-structure">
+
+    % for section in blocks.get('children'):
+
+    <li class="course-section">
+        % if section['resume_block']:
+        <span class="section-id-img"><img class="img-responsive" src="${profile_image_url}" alt="${username}" /></span>
+        % else:
+        <span class="section-id">${loop.index + 1}</span>
+        % endif
+
+
+        % if section['resume_block']:
+        <div
+            class="${loop.cycle('section-content section-content-left section-current-left', 'section-content section-content-opposite section-content-right section-current-right')}">
+        % else:
+        <div
+            class="${loop.cycle('section-content section-content-left', 'section-content section-content-opposite section-content-right')} ${ 'section-current' if section['resume_block'] else '' }">
+        % endif
+            <h2 class="section-heading">${ section['display_name'] }</h2>
+            <div class="section-text">
+                % for subsection in section.get('children', []):
+                    <div class="${ 'current' if subsection['resume_block'] else '' }">
+                        <a href="${ subsection['lms_web_url'] }" id="${ subsection['id'] }">
+                            <p>${ subsection['display_name'] }</p>
+                        </a>
+
+                        % if 'special_exam' in subsection:
+                            ## Display the exam status icon and status message
+                            <i class="menu-icon fa ${subsection['special_exam_info'].get('suggested_icon', 'fa-pencil-square-o')} ${subsection['special_exam_info'].get('status', 'eligible')}"
+                                aria-hidden="true"></i>
+                            <p>
+                                ${subsection['special_exam_info'].get('short_description', '')}
+                            </p>
+                        % endif
+
+                        ## Resume button (if last visited section)
+                        % if subsection['resume_block']:
+                            <a href="${ subsection['lms_web_url'] }" class="btn btn-primary">
+                                ${ _("Resume Course") }
+                                <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+                            </a>
+                        %endif
+                    </div>
+                % endfor
+            </div>
+        </div>
+    </li>
+
+    % endfor
+
+</ul>
+
+% else:
+<div class="well depth-0 message-area">
+    <div class="copy-large">
+        <span class="icon fa fa-calendar-o" aria-hidden="true"></span>
+        <%
+            course_started = course.start.date() <= date.today()
+        %>
+
+        % if course.start_date_is_still_default:
+            ${_("This course has not started yet.")}
+        % elif course_started:
+            ${_("We're still working on course content.")}
+        % else:
+            ${Text(_("This course has not started yet, and will launch on {launch_date_html}.")).format(
+                launch_date_html=HTML(
+                    '<span' '    class="localized-datetime start-date"' '    data-datetime="{start_date}"' '    data-format="shortDate"' '    data-timezone="{user_timezone}"' '    data-language="{user_language}"' '></span>'
+            ).format( start_date=course.start, user_timezone=user_timezone, user_language=user_language, ), )}
+        % endif
+    </div>
+</div>
+% endif
+
+<%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">
+    DateUtilFactory.transform('.localized-datetime');
+</%static:require_module_async>
+
+<%static:webpack entry="CourseOutline">
+    new CourseOutline('.grid');
+</%static:webpack>

--- a/openedx/features/course_experience/templates/course_experience/course-reviews-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/course-reviews-fragment-proversity.html
@@ -1,0 +1,40 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+
+<%!
+from django.utils.translation import ugettext as _
+
+from openedx.core.djangolib.markup import HTML
+from openedx.features.course_experience import course_home_page_title
+%>
+
+
+<div class="course-reviews container" tabindex="-1">
+    <header class="page-header has-secondary">
+        ## Breadcrumb navigation
+        <div class="page-header-main">
+            <nav aria-label="${_('Reviews')}" class="sr-is-focusable" tabindex="-1">
+                <div class="has-breadcrumbs">
+                    <div class="breadcrumbs">
+                        <span class="nav-item">
+                            <a href="${course_url}">${course_home_page_title(course)}</a>
+                        </span>
+                        <span class="icon fa fa-angle-right" aria-hidden="true"></span>
+                        <span class="nav-item">${_('Reviews')}</span>
+                    </div>
+                </div>
+            </nav>
+            % if is_enrolled:
+            <div class="btn toggle-read-write-reviews"></div>
+            % endif
+        </div>
+    </header>
+    <div class="course-reviews-tool">
+        % if course_reviews_fragment:
+        ${HTML(course_reviews_fragment.body_html())}
+        % endif
+    </div>
+</div>

--- a/openedx/features/course_experience/templates/course_experience/course-sock-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/course-sock-fragment-proversity.html
@@ -1,0 +1,76 @@
+## mako
+
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
+%>
+
+<%block name="content">
+    % if show_course_sock:
+    <div class="verification-sock"
+        % if not DISPLAY_COURSE_SOCK_FLAG.is_enabled(course_id):
+        style="display: none"
+        %endif
+    >
+        <button type="button" aria-expanded="false" class="btn btn-primary focusable action-toggle-verification-sock">
+            ${_('Learn About Verified Certificates')}
+        </button>
+        <div class="verification-main-panel">
+            <div class="verification-desc-panel content-main">
+                <h2>${_('{platform_name} Verified Certificate').format(platform_name=settings.PLATFORM_NAME)}</h2>
+                <h3>${_('Why upgrade?')}</h3>
+                <ul>
+                    <li>${_('Official proof of completion')}</li>
+                    <li>${_('Easily shareable certificate')}</li>
+                    <li>${_('Proven motivator to complete the course')}</li>
+                    <li>${_('Certificate purchases help {platform_name} continue to offer free courses').format(platform_name=settings.PLATFORM_NAME)}</li>
+                </ul>
+                <h3>${_('How it works')}</h3>
+                <ul>
+                    <li>${_('Pay the Verified Certificate upgrade fee')}</li>
+                    <li>${_('Verify your identity with a webcam and government-issued ID')}</li>
+                    <li>${_('Study hard and pass the course')}</li>
+                    <li>${_('Share your certificate with friends, employers, and others')}</li>
+                </ul>
+                % if settings.PLATFORM_NAME == 'edX':
+                    <h3>${_('edX Learner Stories')}</h3>
+                    <div class="learner-story-container">
+                        <img class="student-image" alt="Student Image" src="${static.url('course_experience/images/learner-quote.png')}" />
+                        <div class="story-quote">
+                            ${_('My certificate has helped me showcase my knowledge on my \
+                            resume - I feel like this certificate could really help me land \
+                            my dream job!')}
+                            <span class="author">- ${_('{learner_name}, edX Learner').format(learner_name='Christina Fong')}</span>
+                        </div>
+                    </div>
+                    <div class="learner-story-container">
+                        <img class="student-image" alt="Student Image" src="${static.url('course_experience/images/learner-quote2.png')}" />
+                        <div class="story-quote">
+                            ${_('I wanted to include a verified certificate on my resume and my profile to \
+                            illustrate that I am working towards this goal I have and that I have \
+                            achieved something while I was unemployed.')}<br/>
+                            <span class="author">- ${_('{learner_name}, edX Learner').format(learner_name='Cheryl Troell')}</span>
+                        </div>
+                    </div>
+                % endif
+                <img class="mini-cert" alt="Example Certificate Image" src="${static.url('course_experience/images/verified-cert.png')}"/>
+                <a href="${upgrade_url}">
+                    <div class="btn btn-upgrade stuck-top focusable action-upgrade-certificate" data-creative="original_sock" data-position="sock">
+                        ${Text(_('Upgrade ({course_price})')).format(course_price=HTML(course_price))}
+                    </div>
+                </a>
+            </div>
+        </div>
+    </div>
+    %endif
+</%block>
+
+<%static:webpack entry="CourseSock">
+    new CourseSock({
+        el:'.verification-sock'
+    });
+</%static:webpack>

--- a/openedx/features/course_experience/templates/course_experience/course-updates-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/course-updates-fragment-proversity.html
@@ -1,0 +1,55 @@
+## mako
+
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML
+from openedx.features.course_experience import course_home_page_title
+%>
+
+<%block name="content">
+<div class="course-updates container" id="course-container">
+    <header class="page-header has-secondary">
+        ## Breadcrumb navigation
+        <div class="page-header-main">
+            <nav aria-label="${_('Course Updates')}" class="sr-is-focusable" tabindex="-1">
+                <div class="has-breadcrumbs">
+                    <div class="breadcrumbs">
+                        <span class="nav-item">
+                            <a href="${course_url}">${course_home_page_title(course)}</a>
+                        </span>
+                        <span class="icon fa fa-angle-right" aria-hidden="true"></span>
+                        <span class="nav-item">${_('Course Updates')}</span>
+                    </div>
+                </div>
+            </nav>
+        </div>
+    </header>
+    <div class="page-content">
+		% if plain_html_updates:
+            ${HTML(plain_html_updates)}
+        % else:
+            <div class="all-updates">
+                % if updates:
+                    % for index, update in enumerate(updates):
+                        <article class="updates-article">
+                            % if not update.get("is_error"):
+                                <div class="date">${update.get("date")}</div>
+                            % endif
+                            <div class="article-content">
+                                ${HTML(update.get("content"))}
+                            </div>
+                        </article>
+                    % endfor
+                % else:
+                    <div class="well depth-0 message-area">
+                        ${_("This course does not have any updates.")}
+                    </div>
+                % endif
+            </div>
+        % endif
+    </div>
+</div>
+</%block>

--- a/openedx/features/course_experience/templates/course_experience/latest-update-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/latest-update-fragment-proversity.html
@@ -1,0 +1,27 @@
+## mako
+
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+
+ <%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML
+%>
+
+<%block name="content">
+<div class="update-message">
+    <div class="dismiss-message">
+        <button type="button" class="btn-link">
+            <span class="sr">${_("Dismiss")}</span>
+            <span class="icon fa fa-times" aria-hidden="true"></span>
+        </button>
+    </div>
+    <h3>${_("Latest Update")}</h3>
+
+     ${HTML(update_html)}
+</div>
+</%block>
+
+ <%static:webpack entry="LatestUpdate">
+new LatestUpdate( { messageContainer: '.update-message',  dismissButton: '.dismiss-message button'});
+</%static:webpack>

--- a/openedx/features/course_experience/templates/course_experience/welcome-message-fragment-proversity.html
+++ b/openedx/features/course_experience/templates/course_experience/welcome-message-fragment-proversity.html
@@ -1,0 +1,29 @@
+## mako
+
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+
+ <%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.core.djangolib.markup import HTML
+%>
+
+<%block name="content">
+<div class="welcome-message">
+    <div class="dismiss-message">
+        <button type="button" class="btn-link">
+            <span class="sr">${_("Dismiss")}</span>
+            <span class="icon fa fa-times" aria-hidden="true"></span>
+        </button>
+    </div>
+
+     ${HTML(welcome_message_html)}
+</div>
+</%block>
+
+ <%static:webpack entry="WelcomeMessage">
+    new WelcomeMessage({
+        dismissUrl: "${dismiss_url | n, js_escaped_string}",
+    });
+</%static:webpack>

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -1,6 +1,7 @@
 """
 Fragment for rendering the course dates sidebar.
 """
+from django.conf import settings
 from django.http import Http404
 from django.template.loader import render_to_string
 from django.utils.translation import get_language_bidi
@@ -9,6 +10,7 @@ from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_date_blocks, get_course_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 class CourseDatesFragmentView(EdxFragmentView):
@@ -28,7 +30,12 @@ class CourseDatesFragmentView(EdxFragmentView):
         context = {
             'course_date_blocks': course_date_blocks
         }
-        html = render_to_string(self.template_name, context)
+
+        if configuration_helpers.get_value('CUSTOM_COURSE_EXPERIENCE_FRAGMENTS', settings.CUSTOM_COURSE_EXPERIENCE_FRAGMENTS):
+            html = render_to_string('course_experience/course-dates-fragment-proversity.html', context)
+        else:
+            html = render_to_string(self.template_name, context)
+
         dates_fragment = Fragment(html)
         self.add_fragment_resource_urls(dates_fragment)
 

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -2,6 +2,7 @@
 Views for the course home page.
 """
 
+from django.conf import settings
 from django.urls import reverse
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
@@ -24,6 +25,7 @@ from lms.djangoapps.course_goals.api import (
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_banner
 from openedx.features.course_experience.course_tools import CourseToolsPluginManager
 from openedx.features.course_duration_limits.access import generate_course_expired_fragment
@@ -220,5 +222,10 @@ class CourseHomeFragmentView(EdxFragmentView):
             'upgrade_price': upgrade_price,
             'upgrade_url': upgrade_url,
         }
-        html = render_to_string('course_experience/course-home-fragment.html', context)
+
+        if configuration_helpers.get_value('CUSTOM_COURSE_EXPERIENCE_FRAGMENTS', settings.CUSTOM_COURSE_EXPERIENCE_FRAGMENTS):
+            html = render_to_string('course_experience/course-home-fragment-proversity.html', context)
+        else:
+            html = render_to_string('course_experience/course-home-fragment.html', context)
+
         return Fragment(html)

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -5,6 +5,7 @@ View logic for handling course messages.
 from datetime import datetime
 
 from babel.dates import format_date, format_timedelta
+from django.conf import settings
 from django.contrib import auth
 from django.template.loader import render_to_string
 from django.utils.http import urlquote_plus
@@ -24,6 +25,7 @@ from lms.djangoapps.course_goals.api import (
 )
 from lms.djangoapps.course_goals.models import GOAL_KEY_CHOICES
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import CourseHomeMessages
 from student.models import CourseEnrollment
@@ -99,7 +101,11 @@ class CourseHomeMessageFragmentView(EdxFragmentView):
             'username': request.user.username,
         }
 
-        html = render_to_string('course_experience/course-messages-fragment.html', context)
+        if configuration_helpers.get_value('CUSTOM_COURSE_EXPERIENCE_FRAGMENTS', settings.CUSTOM_COURSE_EXPERIENCE_FRAGMENTS):
+            html = render_to_string('course_experience/course-messages-fragment-proversity.html', context)
+        else:
+            html = render_to_string('course_experience/course-messages-fragment.html', context)
+
         return Fragment(html)
 
 

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -5,6 +5,7 @@ import re
 import datetime
 
 from completion import waffle as completion_waffle
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
@@ -15,6 +16,7 @@ from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_overview_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.models import CourseEnrollment
 
 from util.milestones_helpers import get_course_content_milestones
@@ -66,7 +68,10 @@ class CourseOutlineFragmentView(EdxFragmentView):
         context['gated_content'] = gated_content
         context['xblock_display_names'] = xblock_display_names
 
-        html = render_to_string('course_experience/course-outline-fragment.html', context)
+        if configuration_helpers.get_value('CUSTOM_COURSE_EXPERIENCE_FRAGMENTS', settings.CUSTOM_COURSE_EXPERIENCE_FRAGMENTS):
+            html = render_to_string('course_experience/course-outline-fragment-proversity.html', context)
+        else:
+            html = render_to_string('course_experience/course-outline-fragment.html', context)
         return Fragment(html)
 
     def create_xblock_id_and_name_dict(self, course_block_tree, xblock_display_names=None):

--- a/openedx/features/course_experience/views/course_reviews.py
+++ b/openedx/features/course_experience/views/course_reviews.py
@@ -14,6 +14,7 @@ from courseware.courses import get_course_with_access
 from student.models import CourseEnrollment
 from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.course_experience import default_course_url_name
 
 from .. import USE_BOOTSTRAP_FLAG
@@ -73,7 +74,11 @@ class CourseReviewsFragmentView(EdxFragmentView):
             'is_enrolled': is_enrolled,
         }
 
-        html = render_to_string('course_experience/course-reviews-fragment.html', context)
+        if configuration_helpers.get_value('CUSTOM_COURSE_EXPERIENCE_FRAGMENTS', settings.CUSTOM_COURSE_EXPERIENCE_FRAGMENTS):
+            html = render_to_string('course_experience/course-reviews-fragment-proversity.html', context)
+        else:
+            html = render_to_string('course_experience/course-reviews-fragment.html', context)
+
         return Fragment(html)
 
 

--- a/openedx/features/course_experience/views/course_sock.py
+++ b/openedx/features/course_experience/views/course_sock.py
@@ -1,12 +1,14 @@
 """
 Fragment for rendering the course's sock and associated toggle button.
 """
+from django.conf import settings
 from django.template.loader import render_to_string
 from web_fragments.fragment import Fragment
 
 from course_modes.models import get_cosmetic_verified_display_price
 from courseware.date_summary import verified_upgrade_deadline_link, verified_upgrade_link_is_valid
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.models import CourseEnrollment
 
 
@@ -19,7 +21,12 @@ class CourseSockFragmentView(EdxFragmentView):
         Render the course's sock fragment.
         """
         context = self.get_verification_context(request, course)
-        html = render_to_string('course_experience/course-sock-fragment.html', context)
+
+        if configuration_helpers.get_value('CUSTOM_COURSE_EXPERIENCE_FRAGMENTS', settings.CUSTOM_COURSE_EXPERIENCE_FRAGMENTS):
+            html = render_to_string('course_experience/course-sock-fragment-proversity.html', context)
+        else:
+            html = render_to_string('course_experience/course-sock-fragment.html', context)
+
         return Fragment(html)
 
     @staticmethod

--- a/openedx/features/course_experience/views/course_updates.py
+++ b/openedx/features/course_experience/views/course_updates.py
@@ -3,6 +3,7 @@ Views that handle course updates.
 """
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.template.context_processors import csrf
 from django.urls import reverse
@@ -15,6 +16,7 @@ from web_fragments.fragment import Fragment
 from courseware.courses import get_course_info_section_module, get_course_with_access
 from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.course_experience import default_course_url_name
 
 from .. import USE_BOOTSTRAP_FLAG
@@ -103,7 +105,12 @@ class CourseUpdatesFragmentView(EdxFragmentView):
             'disable_courseware_js': True,
             'uses_pattern_library': True,
         }
-        html = render_to_string('course_experience/course-updates-fragment.html', context)
+
+        if configuration_helpers.get_value('CUSTOM_COURSE_EXPERIENCE_FRAGMENTS', settings.CUSTOM_COURSE_EXPERIENCE_FRAGMENTS):
+            html = render_to_string('course_experience/course-updates-fragment-proversity.html', context)
+        else:
+            html = render_to_string('course_experience/course-updates-fragment.html', context)
+
         return Fragment(html)
 
     @classmethod

--- a/openedx/features/course_experience/views/latest_update.py
+++ b/openedx/features/course_experience/views/latest_update.py
@@ -6,12 +6,14 @@ this fragment dismisses the message for a limited time so new updates
 will continue to appear, where the welcome message gets permanently
 dismissed.
 """
+from django.conf import settings
 from django.template.loader import render_to_string
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.course_experience.views.course_updates import get_ordered_updates
 
 
@@ -35,7 +37,12 @@ class LatestUpdateFragmentView(EdxFragmentView):
         context = {
             'update_html': update_html,
         }
-        html = render_to_string('course_experience/latest-update-fragment.html', context)
+
+        if configuration_helpers.get_value('CUSTOM_COURSE_EXPERIENCE_FRAGMENTS', settings.CUSTOM_COURSE_EXPERIENCE_FRAGMENTS):
+            html = render_to_string('course_experience/latest-update-fragment-proversity.html', context)
+        else:
+            html = render_to_string('course_experience/latest-update-fragment.html', context)
+
         return Fragment(html)
 
     @classmethod


### PR DESCRIPTION
## Description:

This PR adds custom course experience .html fragments to the courseware view.
The setting CUSTOM_COURSE_EXPERIENCE_FRAGMENTS was added in order to control the custom fragment views.

## Note:

The TeachFirst theme must be enabled to test this correctly.
The templates are exactly the same from the previous work.

## Previous work:

https://github.com/proversity-org/edx-platform/commit/d96a9f789c50605e68372a0cb2f22a6a740731c0
https://github.com/proversity-org/edx-platform/commit/1f50cc0e5d4f3c144780a56bf117a2ade84ab065

## Screenshots:

![image](https://user-images.githubusercontent.com/17520199/62071255-c026f200-b201-11e9-84a9-2f386e3d1d09.png)
![image](https://user-images.githubusercontent.com/17520199/62071345-ef3d6380-b201-11e9-965a-37c98d69269b.png)


## Reviewers: 

- [ ] @andrey-canon 
- [ ] @diegomillan 