### PR TITLE
MIGRATION-38 - Custom course experience fragments. patch-1.

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1108,7 +1108,10 @@ WRITABLE_GRADEBOOK_URL = ENV_TOKENS.get('WRITABLE_GRADEBOOK_URL', WRITABLE_GRADE
 ############## Settings for use custom course experience fragments. ##############
 # This setting is used to enable the custom proversity fragments stored in
 # openedx/features/course_experience/templates/course_experience/*-proversity.html
-CUSTOM_COURSE_EXPERIENCE_FRAGMENTS = False
+CUSTOM_COURSE_EXPERIENCE_FRAGMENTS = ENV_TOKENS.get(
+    'CUSTOM_COURSE_EXPERIENCE_FRAGMENTS',
+    CUSTOM_COURSE_EXPERIENCE_FRAGMENTS
+)
 
 ############################### Plugin Settings ###############################
 


### PR DESCRIPTION
## Description:

This PR fixes the CUSTOM_COURSE_EXPERIENCE_FRAGMENTS setting in the aws file, getting it from the environment tokens instead of default value.

## Reviewers:

- [ ] @andrey-canon 
- [ ] @diegomillan 