### PR TITLE
MIGRATION-36 - Making the bulk email site aware.

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2729,8 +2729,14 @@ def send_email(request, course_id):
                       course_id, request.user, targets)
         return HttpResponseBadRequest(repr(err))
 
+    # Get the settings from the configuration helpers to make the email context site aware.
+    site_context = {
+        'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
+        'LMS_ROOT_URL': configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+    }
+
     # Submit the task, so that the correct InstructorTask object gets created (for monitoring purposes)
-    lms.djangoapps.instructor_task.api.submit_bulk_course_email(request, course_id, email.id)
+    lms.djangoapps.instructor_task.api.submit_bulk_course_email(request, course_id, email.id, site_context)
 
     response_payload = {
         'course_id': text_type(course_id),

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -289,7 +289,7 @@ def submit_delete_entrance_exam_state_for_student(request, usage_key, student): 
     return submit_task(request, task_type, task_class, usage_key.course_key, task_input, task_key)
 
 
-def submit_bulk_course_email(request, course_key, email_id):
+def submit_bulk_course_email(request, course_key, email_id, site_context):
     """
     Request to have bulk email sent as a background task.
 
@@ -314,7 +314,7 @@ def submit_bulk_course_email(request, course_key, email_id):
 
     task_type = 'bulk_course_email'
     task_class = send_bulk_course_email
-    task_input = {'email_id': email_id, 'to_option': targets}
+    task_input = {'email_id': email_id, 'to_option': targets, 'site_context': site_context}
     task_key_stub = str(email_id)
     # create the key value by using MD5 hash:
     task_key = hashlib.md5(task_key_stub).hexdigest()

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -253,7 +253,8 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
         api_call = lambda: submit_bulk_course_email(
             self.create_task_request(self.instructor),
             self.course.id,
-            email_id
+            email_id,
+            {},
         )
         self._test_resubmission(api_call)
 


### PR DESCRIPTION
## Description:

This PR makes the bulk email feature site aware, adding the platform_name and the LMS_ROOT_URL settings to the email context.

## Previous work:

https://github.com/proversity-org/edx-platform/commit/26a91cfc35e17386f4862d7567b1ebd3b09c416b

## Notes:

In order to see the email tab in the instructor tab, the bulk email feature must be enabled from the admin page.

## Reviewers:

- [ ] @andrey-canon 
- [ ] @diegomillan 