### PR TITLE
PE-619 Add extended_profile_fields to the register form

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -275,9 +275,15 @@ class AccountCreationForm(forms.Form):
                         }
                     )
 
+        extended_profile_field_options = configuration_helpers.get_value('EXTRA_FIELD_OPTIONS', [])
+
         for field in self.extended_profile_fields:
-            if field not in self.fields:
-                self.fields[field] = forms.CharField(required=False)
+            options = [(value, _(value)) for value in extended_profile_field_options.get(field, [])]
+
+            if field not in self.fields and options:
+                self.fields[field] = forms.ChoiceField(required=True, choices=options)
+            elif field not in self.fields:
+                self.fields[field] = forms.CharField(required=True)
 
     def clean_password(self):
         """Enforce password policies (if applicable)"""

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -275,10 +275,10 @@ class AccountCreationForm(forms.Form):
                         }
                     )
 
-        extended_profile_field_options = configuration_helpers.get_value('EXTRA_FIELD_OPTIONS', [])
+        extra_field_options = configuration_helpers.get_value('EXTRA_FIELD_OPTIONS', [])
 
         for field in self.extended_profile_fields:
-            options = [(value, _(value)) for value in extended_profile_field_options.get(field, [])]
+            options = [(value, _(value)) for value in extra_field_options.get(field, [])]
 
             if field not in self.fields and options:
                 self.fields[field] = forms.ChoiceField(required=True, choices=options)

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -911,26 +911,28 @@ class RegistrationFormFactory(object):
             },
         )
 
-    def _add_extended_profile_field(self, form_desc, field, required=True):
+    def _add_extended_profile_field(self, form_desc, field):
         """Add a field to a form description.
         Arguments:
-            form_desc: A form description
-            field: the field name defined on extended_profile_fields
+            form_desc: A form description.
+            field: the field name defined on extended_profile_fields.
         Keyword Arguments:
-            required (bool): Whether this field is required; defaults to True
+            required (bool): Whether this field is required; defaults to True.
         """
-
-        extended_profile__label = _(field)
-
-        extended_profile_field_options = configuration_helpers.get_value('EXTRA_FIELD_OPTIONS', [])
-
-        options = [(value, _(value)) for value in extended_profile_field_options.get(field, [])]
+        extended_profile_label = _(field)
+        extra_field_options = configuration_helpers.get_value('EXTRA_FIELD_OPTIONS', [])
+        options = [(value, _(value)) for value in extra_field_options.get(field, [])]
+        registration_extra_fields = configuration_helpers.get_value(
+            'REGISTRATION_EXTRA_FIELDS',
+            settings.REGISTRATION_EXTRA_FIELDS,
+        )
+        required = True if registration_extra_fields.get(field, '') != 'hidden' else False
 
         if options:
             form_desc.add_field(
                 field,
-                field_type="select",
-                label=extended_profile__label,
+                field_type='select',
+                label=extended_profile_label,
                 include_default_option=True,
                 options=options,
                 required=required,
@@ -938,7 +940,7 @@ class RegistrationFormFactory(object):
         else:
             form_desc.add_field(
                 field,
-                label=extended_profile__label,
+                label=extended_profile_label,
                 include_default_option=True,
                 required=required,
             )

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -299,6 +299,9 @@ class RegistrationFormFactory(object):
                         required=self._is_field_required(field_name)
                     )
 
+        for field in configuration_helpers.get_value('extended_profile_fields', []):
+            self._add_extended_profile_field(form_desc, field)
+
         return form_desc
 
     def _add_email_field(self, form_desc, required=True):
@@ -907,6 +910,38 @@ class RegistrationFormFactory(object):
                 "required": error_msg
             },
         )
+
+    def _add_extended_profile_field(self, form_desc, field, required=True):
+        """Add a field to a form description.
+        Arguments:
+            form_desc: A form description
+            field: the field name defined on extended_profile_fields
+        Keyword Arguments:
+            required (bool): Whether this field is required; defaults to True
+        """
+
+        extended_profile__label = _(field)
+
+        extended_profile_field_options = configuration_helpers.get_value('EXTRA_FIELD_OPTIONS', [])
+
+        options = [(value, _(value)) for value in extended_profile_field_options.get(field, [])]
+
+        if options:
+            form_desc.add_field(
+                field,
+                field_type="select",
+                label=extended_profile__label,
+                include_default_option=True,
+                options=options,
+                required=required,
+            )
+        else:
+            form_desc.add_field(
+                field,
+                label=extended_profile__label,
+                include_default_option=True,
+                required=required,
+            )
 
     def _apply_third_party_auth_overrides(self, request, form_desc):
         """Modify the registration form if the user has authenticated with a third-party provider.


### PR DESCRIPTION
## Description
Add extended_profile_fields to the register form.
## How to test
1) Add in the site configurations a dict with the name  `extended_profile_fields`, example:
``` 
"extended_profile_fields":[
    "group",
    "number"
  ] 
```
2) there are two possibilities, text field or choice fields, if you wan add choices, add in the site configurations a dict with the name  `EXTRA_FIELD_OPTIONS`, example:
```
  "EXTRA_FIELD_OPTIONS":{
    "group":[
      "group1",
      "group2"
    ]
  }
```