### PR TITLE
PE-665 - Add support for extended profile fields name mapping.

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -393,6 +393,10 @@ def _get_extended_profile_fields():
         "specialty": _(u"Specialty")
     }
 
+    field_labels_map.update(
+        configuration_helpers.get_value('extended_profile_fields_name_mapping', {}),
+    )
+
     extended_profile_field_names = configuration_helpers.get_value('extended_profile_fields', [])
     for field_to_exclude in fields_already_showing:
         if field_to_exclude in extended_profile_field_names:


### PR DESCRIPTION
## Description:

This PR adds support for field name mapping to the extended profile fields.
Now you can set the display name of the fields using a settings called: extended_profile_fields_name_mapping
e.g. 
"extended_profile_fields_name_mapping":{
    "my_extended_profile_field": "My extended profile field display name."
}

## Reviewers:

- [ ] @andrey-canon 