### PR TITLE
PE-899: Fix to prevent 500 error when the currency for a course differs from the one configured in Ansible

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -681,7 +681,10 @@ class CourseMode(models.Model):
         If there is no mode found, will return the price of DEFAULT_MODE, which is 0
         """
         modes = cls.modes_for_course(course_id)
-        return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        try:
+            return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        except ValueError:
+            return 0
 
     @classmethod
     def is_eligible_for_certificate(cls, mode_slug):


### PR DESCRIPTION
This PR applies a quick fix to prevent the 500 error in the about page of a course. This error happens when the currency configured in the course mode (usd for example) is different to the one configured in PAID_COURSE_REGISTRATION_CURRENCY (gbp for example)  for the tenant.