### PR TITLE
Adding log to help debug issue with ccx course not being found

### DIFF
--- a/lms/djangoapps/ccx/overrides.py
+++ b/lms/djangoapps/ccx/overrides.py
@@ -69,6 +69,8 @@ def get_current_ccx(course_key):
 
     ccx_cache = get_cache('ccx')
     if course_key not in ccx_cache:
+        msg = "There is no CCX with id %r for course %r"
+        log.error(msg, course_key.ccx, course_key)
         ccx_cache[course_key] = CustomCourseForEdX.objects.get(pk=course_key.ccx)
 
     return ccx_cache[course_key]


### PR DESCRIPTION
This is log is added to help fix an issue that is generating a 500 error when an user logs in. 

This is the log that shows the error:

` File "/tmp/mako_lms/cdea31ec570b95019fc34da96e570523/pearson-pols-theme/lms/templates/dashboard/_dashboard_course_listing.html.py", line 86, in render_body
    course_display_tab = '_blank' if course.other_course_settings.get('external_course_run_id')\
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/fields.py", line 518, in __get__
    if field_data.has(xblock, self.name):
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/field_overrides.py", line 230, in has
    has = self.get_override(block, name)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/field_overrides.py", line 209, in get_override
    value = provider.get(block, name, NOTSET)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/ccx/overrides.py", line 44, in get
    ccx = get_current_ccx(course_key)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/ccx/overrides.py", line 72, in get_current_ccx
    ccx_cache[course_key] = CustomCourseForEdX.objects.get(pk=course_key.ccx)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 380, in get
    self.model._meta.object_name
DoesNotExist: CustomCourseForEdX matching query does not exist.`

The cause may be a ccx course that was deleted but still shows into the user's enrollments.