### PR TITLE
PE-709 - Avoid automatic staff enrollment when creating CCX courses.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -51,6 +51,7 @@ from lms.djangoapps.ccx.utils import (
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params
 from lms.djangoapps.instructor.views.gradebook_api import get_grade_book_page
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.models import CourseEnrollment
 from student.roles import CourseCcxCoachRole
 from xmodule.modulestore.django import SignalHandler
@@ -231,7 +232,9 @@ def create_ccx(request, course, ccx=None):
     )
 
     assign_staff_role_to_ccx(ccx_id, request.user, course.id)
-    add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
+
+    if configuration_helpers.get_value('ALLOW_ENROLL_STAFF_TO_CCX', True):
+        add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
 
     # using CCX object as sender here.
     responses = SignalHandler.course_published.send(


### PR DESCRIPTION
## Description:

This PR adds a new site configuration called: ALLOW_ENROLL_STAFF_TO_CCX to prevent automatic enrollments of master course staff members when creating a CCX course.

## Previous work:

- https://github.com/proversity-org/edx-platform/pull/1104

## Reviewers:

- [ ] @diegomillan 