### PR TITLE
PAE-124 - Return the user course access role in Gradebook view.

### DIFF
--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -432,3 +432,15 @@ def remove_master_course_staff_from_ccx(master_course, ccx_key, display_name, se
                     email_students=send_email,
                     email_params=email_params,
                 )
+
+
+def get_master_course_by_ccx_id(ccx_id):
+    """
+    Return the master course id by the given CCX course id.
+
+    Args:
+        ccx_id: CCXLocator instance.
+    Returns:
+        None or a CourseLocator instance.
+    """
+    return ccx_id.to_course_locator() if ccx_id else None


### PR DESCRIPTION
## Description:

This PR adds functionality in the Gradebook view to check if the user has staff access in the master course.

## Configuration:

This functionality is handled by a site configuration setting: HIDE_MASTER_COURSE_STAFF_FROM_GRADEBOOK set it to 'true' if you want to hide staff users of the course master from Gradebook view.

## Reviewers:

- [ ] @andrey-canon 
- [ ] @diegomillan 