### PR TITLE
PAE-133 - Exclude master course staff users from gradebook download.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -542,6 +542,13 @@ def ccx_grades_csv(request, course, ccx=None):
             courseenrollment__course_id=ccx_key,
             courseenrollment__is_active=1
         ).order_by('username').select_related("profile")
+
+        if configuration_helpers.get_value('HIDE_MASTER_COURSE_STAFF_FROM_GRADEBOOK', False):
+            enrolled_students = exclude_master_course_staff_users(
+                users=enrolled_students,
+                course_key=ccx_key,
+            )
+
         grades = CourseGradeFactory().iter(enrolled_students, course)
 
         header = None


### PR DESCRIPTION
## Description:

This PR adds the functionality to exclude users depending on whether they are staff members in the master course and avoid showing them on the grade download file.

## Configuration:

This functionality is handled by a site configuration setting: HIDE_MASTER_COURSE_STAFF_FROM_GRADEBOOK set it to 'true' if you want to hide master course staff members from the grade download file.

## Reviewers:

- [ ] @diegomillan 
- [ ] @andrey-canon 